### PR TITLE
ESP32-P4 port with PIE vector kernels, plus serial prompting for TinyStories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ videos/
 *.mov
 *.MOV
 *.MP4
+
+# Claude Code plugin memory, personal to this machine
+.claude/

--- a/firmware/esp32_barista/tools/generate_tokenizer_header.py
+++ b/firmware/esp32_barista/tools/generate_tokenizer_header.py
@@ -116,8 +116,14 @@ def read_tokenizer(path):
     return path.read_bytes()
 
 
-def check_encoding_contract(config):
-    """Reject any configuration the device encoder does not implement."""
+def check_encoding_contract(config, allow_special_added_tokens=False):
+    """Reject any configuration the device encoder does not implement.
+
+    allow_special_added_tokens accepts added tokens marked special, such as
+    TinyStories' <|endoftext|>. The device never needs to encode one: a
+    special token is emitted by the model, not typed by a user, and its literal
+    text typed at the prompt is encoded as ordinary bytes instead.
+    """
     model = config.get("model") or {}
     if model.get("type") != "BPE":
         raise SystemExit(
@@ -129,9 +135,12 @@ def check_encoding_contract(config):
             raise SystemExit(
                 f"{field} is configured; the device encoder applies none"
             )
-    if config.get("added_tokens"):
+    added = config.get("added_tokens") or []
+    if allow_special_added_tokens:
+        added = [t for t in added if not t.get("special")]
+    if added:
         raise SystemExit(
-            f"{len(config['added_tokens'])} added tokens are configured; the "
+            f"{len(added)} added tokens are configured; the "
             f"asset carries no table for them"
         )
 
@@ -204,10 +213,10 @@ def merge_pairs(merges):
     return pairs
 
 
-def build_asset(source):
+def build_asset(source, allow_special_added_tokens=False):
     """Pack the BTK1 asset from the raw bytes of tokenizer.json."""
     config = json.loads(source)
-    check_encoding_contract(config)
+    check_encoding_contract(config, allow_special_added_tokens)
 
     vocab = config["model"]["vocab"]
     merges = config["model"]["merges"]
@@ -299,7 +308,8 @@ def render(asset):
     return "\n".join(lines) + "\n"
 
 
-def generate(tokenizer_path, out_path, asset_path=None):
+def generate(tokenizer_path, out_path, asset_path=None,
+             allow_special_added_tokens=False):
     """Validate the tokenizer and write the header. Returns the path.
 
     asset_path additionally writes the raw BTK1 bytes, which is what the host
@@ -307,7 +317,8 @@ def generate(tokenizer_path, out_path, asset_path=None):
     recompiled against a header for every tokenizer.
     """
     source = read_tokenizer(tokenizer_path)
-    asset, active_vocab, merge_count, merge_base = build_asset(source)
+    asset, active_vocab, merge_count, merge_base = build_asset(
+        source, allow_special_added_tokens)
 
     out_path = Path(out_path)
     # Generated headers are ignored, so the directory is absent in a fresh clone.
@@ -333,8 +344,10 @@ def main():
     ap.add_argument("--out", default=DEFAULT_OUT, help="header to write")
     ap.add_argument("--asset", default=None,
                     help="also write the raw BTK1 bytes here, for host checks")
+    ap.add_argument("--allow-special-added-tokens", action="store_true",
+                    help="accept added tokens marked special, e.g. <|endoftext|>")
     args = ap.parse_args()
-    generate(args.tokenizer, args.out, args.asset)
+    generate(args.tokenizer, args.out, args.asset, args.allow_special_added_tokens)
 
 
 if __name__ == "__main__":

--- a/firmware/esp32_tinystories/esp32_tinystories.ino
+++ b/firmware/esp32_tinystories/esp32_tinystories.ino
@@ -281,8 +281,13 @@ static void alloc_scratch() {
   // rather than spend a fifth of internal SRAM on it.
   s.logits = (float *)ps_or_die((size_t)model.out_vocab * 4, "logits");
 #ifdef LLM_KV_QUANT
-  // Quantized KV cache: int8 keys, int16 transposed values, about 540 KB.
-  llm_kv_quant_bind(&model, &s, ps_or_die(llm_kv_quant_bytes(&model), "kv cache"));
+  // Quantized KV cache. The int8 keys (192 KB) are read for every position at
+  // every step, so they go to internal SRAM with the per-head temporaries;
+  // the int16 values and the scales (about 340 KB) stay in PSRAM.
+  llm_kv_quant_bind(&model, &s,
+                    ps_or_die(llm_kv_main_bytes(&model), "kv values"),
+                    sram_or_die(llm_kv_key_bytes(&model), "kv keys"),
+                    sram_or_die(llm_kv_hot_bytes(&model), "kv temporaries"));
   s.kcache = s.vcache = NULL;
 #else
   // KV cache: 1.1MB, read once per position rather than per matvec.

--- a/firmware/esp32_tinystories/esp32_tinystories.ino
+++ b/firmware/esp32_tinystories/esp32_tinystories.ino
@@ -1,4 +1,4 @@
-// PLE TinyLM inference on the ESP32-S3.
+// PLE TinyLM inference on the ESP32-S3, prompted over serial.
 //
 // The 28.9M-param model (14.9MB, 4-bit) lives in a flash 'model' partition,
 // memory-mapped. Placement follows reads-per-token rather than what happens to
@@ -9,8 +9,12 @@
 //   PSRAM   staged int8 core + head, KV   read once per position
 //   SRAM    scratch + norm vectors        touched many times per token
 //
-// The logits array stays in PSRAM: 25,353 floats is 99 KiB, and the argmax
+// The logits array stays in PSRAM: 25,353 floats is 99 KiB, and the sampler
 // reads it once per token.
+//
+// Type a prompt (ASCII, up to 512 bytes) and press return. It is encoded on
+// the device with the same ByteLevel BPE the model was trained with, then the
+// story is sampled one token at a time and streamed back.
 //
 // Same llm.h that is verified against PyTorch on the host; only the platform
 // hooks differ here.
@@ -18,6 +22,7 @@
 #include "esp_partition.h"
 #include "esp_heap_caps.h"
 #include "esp_timer.h"
+#include "esp_random.h"
 
 // int8 activations, required by the staged int8 kernel. Not bit-exact against
 // the fp32 golden; verify.c must be built without this flag. Validation CE cost
@@ -25,21 +30,39 @@
 #define LLM_INT8_ACT 1
 #define LLM_PROFILE 1
 #define LLM_PROFILE_NOW() esp_timer_get_time()
+// On the ESP32-P4 the staged int8 rows are padded to 16 bytes so the PIE
+// vector kernel reads whole vectors; every other target keeps rows packed.
+#if CONFIG_IDF_TARGET_ESP32P4
+#define LLM_STAGE_ALIGN 16
+#endif
 #include "../../runtime/llm.h"
+#include "../../runtime/llm_pie.h"
+#include "../../runtime/bpe_tokenizer.h"
 #include "generated/vocab.h"
+#include "generated/tokenizer_encoder.h"
 
 // Set to 1 once a display is wired up - see display.h.
 // Leave 0 to run serial-only (no panel needed).
-#define USE_DISPLAY 1
+#define USE_DISPLAY 0
 #if USE_DISPLAY
 #include "display.h"
 #endif
 
-static const int PROMPT_IDS[] = {433, 447, 259, 405}; // "Once upon a time"
+// Tokens generated after the prompt, unless the story ends or the context fills.
 static const int N_GENERATE = 200;
+// Positions kept for the story, so a long prompt cannot leave nothing to write.
+#define STORY_ROOM 64
+// <|endoftext|> in the TinyStories tokenizer: the model emits it when a story ends.
+#define EOT_ID 0
+// Sampling, the same scheme as TinyLM.generate() in src/model.py. TEMPERATURE 0
+// selects greedy decoding, which reproduces the original fixed-prompt demo.
+static const float TEMPERATURE = 0.8f;
+static const int TOP_K = 40;
 
-Model model;
-Scratch s;
+static Model model;
+static Scratch s;
+static BpeTokenizer tokenizer;
+static bool ready = false;
 
 // ---- allocation ------------------------------------------------------------
 // Allocations are strict because memory placement is part of the runtime
@@ -53,7 +76,8 @@ static size_t psram_used = 0, sram_used = 0;
 #define STATIC_SRAM_BYTES (2 * LLM_Q8_MAX_INPUT)
 
 static void *ps(size_t n) {
-  void *p = heap_caps_malloc(n, MALLOC_CAP_SPIRAM);
+  // 16-byte aligned: staged weight rows must start on vector boundaries.
+  void *p = heap_caps_aligned_alloc(16, n, MALLOC_CAP_SPIRAM);
   if (p) psram_used += n;
   return p;
 }
@@ -79,7 +103,8 @@ static void *sram_or_die(size_t n, const char *what) {
 
 // ---- dual-core int8 matvec -------------------------------------------------
 // Serves both hooks. Below ~128 rows the task notify round trip costs more than
-// the split saves, so small tensors run single-core.
+// the split saves, so small tensors run single-core. On the ESP32-P4 the rows
+// go through the PIE vector kernel; elsewhere through the scalar one.
 static TaskHandle_t worker_h, main_h;
 static const QT *job_t;
 static const int8_t *job_xq;
@@ -87,24 +112,71 @@ static float job_xs;
 static float *job_y;
 static int job_split;
 
+// Ranged int8 matvec for one staged tensor on the calling core.
+static void matvec_rows(const QT *t, const int8_t *xq, float xs, float *y,
+                        int row_begin, int row_end) {
+#if LLM_HAVE_PIE
+  if (llm_pie_ok(t)) { matvec_pie_range(t, xq, xs, y, row_begin, row_end); return; }
+#endif
+  matvec_i8_range(t, xq, xs, y, row_begin, row_end);
+}
+
 static void worker_main(void *) {
   for (;;) {
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-    matvec_i8_range(job_t, job_xq, job_xs, job_y, 0, job_split);
+    matvec_rows(job_t, job_xq, job_xs, job_y, 0, job_split);
     xTaskNotifyGive(main_h);
   }
 }
 
-static void matvec_par(const QT *t, const float *x, float *y) {
-  static int8_t xq[LLM_Q8_MAX_INPUT];
+// Quantize x into the shared activation buffer. The vector kernel reads the
+// row's padded width, so the bytes past cols are cleared every call: the
+// previous tensor may have been wider and left its values there.
+static int8_t xq_shared[LLM_Q8_MAX_INPUT] __attribute__((aligned(16)));
+static float quantize_shared(const QT *t, const float *x) {
   float xs;
-  if (t->w8 == NULL || t->rows < 128) { MATVEC(t, x, y); return; }
-  quantize_act(x, t->cols, xq, &xs);   // once; both cores read the result
-  job_t = t; job_xq = xq; job_xs = xs; job_y = y; job_split = t->rows / 2;
+  quantize_act(x, t->cols, xq_shared, &xs);
+  for (int j = t->cols; j < t->stride8; j++) xq_shared[j] = 0;
+  return xs;
+}
+
+static void matvec_par(const QT *t, const float *x, float *y) {
+  if (t->w8 == NULL) { MATVEC(t, x, y); return; }
+  float xs = quantize_shared(t, x);      // once; both cores read the result
+  if (t->rows < 128) { matvec_rows(t, xq_shared, xs, y, 0, t->rows); return; }
+  job_t = t; job_xq = xq_shared; job_xs = xs; job_y = y; job_split = t->rows / 2;
   xTaskNotifyGive(worker_h);
-  matvec_i8_range(t, xq, xs, y, job_split, t->rows);
+  matvec_rows(t, xq_shared, xs, y, job_split, t->rows);
   ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
 }
+
+#if LLM_HAVE_PIE
+// The vector kernel must reproduce the scalar kernel exactly: same integer
+// sums, same float operations in the same order. Check one tensor of each
+// width the model has, plus a slice of the head, before trusting it.
+static bool pie_self_check() {
+  const QT *cases[] = { &model.ple_model_proj, &model.qkv[0], &model.down[0],
+                        &model.ple_proj[0], &model.out_head };
+  static float ref[1024], got[1024], x[LLM_Q8_MAX_INPUT];
+  double worst = 0;
+  for (unsigned c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+    const QT *t = cases[c];
+    if (!llm_pie_ok(t)) { Serial.printf("pie: tensor %u not eligible\n", c); return false; }
+    for (int j = 0; j < t->cols; j++) x[j] = sinf(0.37f * j + c) * 1.7f;
+    float xs = quantize_shared(t, x);
+    int rows = t->rows < 1024 ? t->rows : 1024;
+    matvec_i8_range(t, xq_shared, xs, ref, 0, rows);
+    matvec_pie_range(t, xq_shared, xs, got, 0, rows);
+    for (int r = 0; r < rows; r++) {
+      double d = fabs((double)ref[r] - got[r]);
+      if (d > worst) worst = d;
+    }
+  }
+  Serial.printf("pie self-check: max |vector - scalar| = %g -> %s\n", worst,
+                worst == 0 ? "ok" : "FAIL");
+  return worst == 0;
+}
+#endif
 
 // Copy RMSNorm weights from mapped flash to internal SRAM.
 static void copy_norms_to_sram() {
@@ -170,10 +242,110 @@ static void emit(int tok) {
 #endif
 }
 
+// ---- sampling ---------------------------------------------------------------
+// Next token from the logits: greedy at TEMPERATURE 0, otherwise a draw from
+// the TOP_K most likely tokens at TEMPERATURE. One pass over the logits keeps
+// a small list sorted by score; the softmax then runs over that list only.
+#define TOP_K_MAX 64
+static int pick_token(const float *logits, int n) {
+  if (TEMPERATURE <= 0.f || TOP_K <= 0) {
+    int best = 0;
+    for (int v = 1; v < n; v++) if (logits[v] > logits[best]) best = v;
+    return best;
+  }
+  static int idx[TOP_K_MAX];
+  static float sc[TOP_K_MAX];
+  int k = TOP_K > TOP_K_MAX ? TOP_K_MAX : TOP_K, cnt = 0;
+  for (int v = 0; v < n; v++) {
+    float l = logits[v];
+    if (cnt == k && l <= sc[k - 1]) continue;
+    int i = (cnt < k) ? cnt++ : k - 1;
+    while (i > 0 && sc[i - 1] < l) { sc[i] = sc[i - 1]; idx[i] = idx[i - 1]; i--; }
+    sc[i] = l; idx[i] = v;
+  }
+  float mx = sc[0], sum = 0.f;
+  for (int i = 0; i < cnt; i++) { sc[i] = expf((sc[i] - mx) / TEMPERATURE); sum += sc[i]; }
+  float r = (float)esp_random() / 4294967296.0f * sum;
+  for (int i = 0; i < cnt; i++) { r -= sc[i]; if (r <= 0.f) return idx[i]; }
+  return idx[cnt - 1];
+}
+
+// ---- generation -------------------------------------------------------------
+static void tell_story(const char *prompt) {
+  uint16_t ids[BTK_MAX_INPUT_BYTES];
+  int n = bpe_encode_ascii(&tokenizer, prompt, ids, BTK_MAX_INPUT_BYTES);
+  if (n == BTK_ERR_NOT_ASCII) { Serial.println("(ascii only)"); return; }
+  int max_prompt = model.c.seq_len - STORY_ROOM;
+  if (n <= 0 || n > max_prompt) {
+    Serial.printf("(prompt too long: %d tokens, max %d)\n", n, max_prompt);
+    return;
+  }
+
+  // Prime with the prompt. The KV cache is simply overwritten from position 0.
+  Serial.print(">>> ");
+  int pos = 0, tok = 0;
+  for (int i = 0; i < n; i++) {
+    tok = ids[i];
+    emit(tok);
+    llm_forward(&model, tok, pos++, &s);
+  }
+
+  llm_profile_reset(&s);
+  int64_t t_start = esp_timer_get_time(), decode_us = 0;
+  int decoded = 0;
+  for (int step = 0; step < N_GENERATE && pos < model.c.seq_len; step++) {
+    tok = pick_token(s.logits, model.out_vocab);
+    if (tok == EOT_ID) break;
+    emit(tok);
+    blink((step & 1) ? 40 : 8);
+
+    int64_t d0 = esp_timer_get_time();
+    llm_forward(&model, tok, pos++, &s);
+    decode_us += esp_timer_get_time() - d0;
+    decoded++;
+    if ((step & 7) == 0) delay(0);  // feed the task WDT ~every 8 tokens
+  }
+  int64_t total_us = esp_timer_get_time() - t_start;
+  blink(0);
+
+  Serial.printf("\n\n--- %d prompt + %d generated tokens in %.2f s ---\n",
+                n, decoded, total_us / 1e6);
+  if (decoded) {
+    Serial.printf("throughput: %.2f tok/s   (%.1f ms/token)\n",
+                  decoded * 1e6 / total_us, decode_us / 1000.0 / decoded);
+  }
+  if (s.profile.calls) {
+    float k = (float)s.profile.calls * 1000.f;
+    Serial.printf("profile ms/token: input %.1f | attn %.1f | ffn %.1f | ple %.1f | head %.1f\n",
+                  s.profile.input_us / k, s.profile.attn_us / k,
+                  s.profile.ffn_us / k, s.profile.ple_us / k,
+                  s.profile.head_us / k);
+  }
+#if USE_DISPLAY
+  if (decoded) display_stats(decoded * 1e6f / decode_us, decode_us / 1000.0f / decoded);
+#endif
+}
+
+// The line buffer holds BTK_MAX_INPUT_BYTES, but the CDC receive queue defaults
+// to 256, so a longer paste would overrun it before loop() drains it.
+#define SERIAL_RX_BYTES (2 * BTK_MAX_INPUT_BYTES)
+
 void setup() {
+  // Must be requested before begin(); a failed request falls back to 256.
+  size_t rx_bytes = Serial.setRxBufferSize(SERIAL_RX_BYTES);
   Serial.begin(115200);
   delay(1500);
-  Serial.println("\n=== ESP32-S3 PLE TinyLM ===");
+  Serial.printf("\n=== %s PLE TinyLM ===\n", CONFIG_IDF_TARGET);
+  if (rx_bytes != SERIAL_RX_BYTES) {
+    Serial.println("serial RX buffer allocation failed");
+    return;
+  }
+
+  if (bpe_tokenizer_load(TOKENIZER_ENCODER_ASSET, TOKENIZER_ENCODER_ASSET_SIZE,
+                         &tokenizer)) {
+    Serial.println("tokenizer load failed");
+    return;
+  }
 
   const esp_partition_t *part = esp_partition_find_first(
       ESP_PARTITION_TYPE_DATA, (esp_partition_subtype_t)0x40, "model");
@@ -195,11 +367,16 @@ void setup() {
 #endif
 
   // The model header states how many logits it produces; vocab.h carries the
-  // decode table. If they disagree, every emitted token would be decoded
-  // against the wrong table.
+  // decode table and the encoder asset the merge table. All three come from
+  // the same tokenizer, so any disagreement means a stale header.
   if (VOCAB_N != model.out_vocab) {
     Serial.printf("FATAL: tokenizer/model mismatch: vocab.h %d, model %d\n",
                   VOCAB_N, model.out_vocab);
+    return;
+  }
+  if ((int)tokenizer.active_vocab != VOCAB_N) {
+    Serial.printf("FATAL: encoder/decoder mismatch: encoder %u ids, vocab.h %d\n",
+                  (unsigned)tokenizer.active_vocab, VOCAB_N);
     return;
   }
 
@@ -226,6 +403,10 @@ void setup() {
   Serial.printf("weights-> PSRAM  %d tensors int8, %.2f MB allocated\n",
                 staged, psram_used / 1048576.0);
 
+#if LLM_HAVE_PIE
+  if (!pie_self_check()) { Serial.println("FATAL: PIE kernel disagrees with scalar"); return; }
+#endif
+
   main_h = xTaskGetCurrentTaskHandle();
   if (xTaskCreatePinnedToCore(worker_main, "mv", 4096, NULL, 2, &worker_h, 0) == pdPASS) {
     // After the worker exists: matvec_par notifies worker_h.
@@ -246,56 +427,43 @@ void setup() {
                   (unsigned)(sram_used + STATIC_SRAM_BYTES),
                   psram_used / 1048576.0);
   }
-  Serial.printf("free: sram %.0f KB | psram %.2f MB\n\n",
+  Serial.printf("free: sram %.0f KB | psram %.2f MB\n",
                 heap_caps_get_free_size(MALLOC_CAP_INTERNAL) / 1024.0,
                 heap_caps_get_free_size(MALLOC_CAP_SPIRAM) / 1048576.0);
-
-  // ---- generate ----
-  Serial.print(">>> ");
-  int n_prompt = sizeof(PROMPT_IDS) / sizeof(int);
-  int pos = 0, tok = 0;
-  int64_t decode_us = 0;
-  int decoded = 0;
-
-  for (int i = 0; i < n_prompt; i++) {  // prime with the prompt
-    tok = PROMPT_IDS[i];
-    emit(tok);
-    llm_forward(&model, tok, pos++, &s);
-  }
-
-  llm_profile_reset(&s);
-
-  int64_t t_start = esp_timer_get_time();
-  for (int step = 0; step < N_GENERATE && pos < model.c.seq_len; step++) {
-    int best = 0; float bv = -1e30f;
-    for (int v = 0; v < model.out_vocab; v++)
-      if (s.logits[v] > bv) { bv = s.logits[v]; best = v; }
-    tok = best;
-    emit(tok);
-    blink((step & 1) ? 40 : 8);
-
-    int64_t d0 = esp_timer_get_time();
-    llm_forward(&model, tok, pos++, &s);
-    decode_us += esp_timer_get_time() - d0;
-    decoded++;
-    if ((step & 7) == 0) delay(0);  // feed the task WDT ~every 8 tokens
-  }
-  int64_t total_us = esp_timer_get_time() - t_start;
-
-  Serial.printf("\n\n--- %d tokens in %.2f s ---\n", decoded, total_us / 1e6);
-  Serial.printf("throughput: %.2f tok/s   (%.1f ms/token)\n",
-                decoded * 1e6 / total_us, decode_us / 1000.0 / decoded);
-  if (s.profile.calls) {
-    float n = (float)s.profile.calls * 1000.f;
-    Serial.printf("profile ms/token: input %.1f | attn %.1f | ffn %.1f | ple %.1f | head %.1f\n",
-                  s.profile.input_us / n, s.profile.attn_us / n,
-                  s.profile.ffn_us / n, s.profile.ple_us / n,
-                  s.profile.head_us / n);
-  }
-#if USE_DISPLAY
-  display_stats(decoded * 1e6f / decode_us, decode_us / 1000.0f / decoded);
-#endif
-  blink(0);
+  Serial.printf("sampling: temperature %.2f, top-k %d | matvec kernel: %s\n\n",
+                TEMPERATURE, TOP_K, LLM_HAVE_PIE ? "PIE vector" : "scalar");
+  Serial.println("type a story prompt and press return.");
+  // A UART bridge can deliver a glitch byte around reset. Anything received
+  // before this point is not a prompt, so drop it rather than let it poison
+  // the first line typed.
+  while (Serial.available()) Serial.read();
+  ready = true;
+  Serial.println("READY>");
 }
 
-void loop() { delay(10000); }
+void loop() {
+  static char line[BTK_MAX_INPUT_BYTES];
+  static int len = 0;
+  static bool overflowed = false;
+  if (!ready) { delay(1000); return; }
+  while (Serial.available()) {
+    char ch = Serial.read();
+    if (ch == '\r') continue;
+    if (ch == '\n') {
+      line[len] = '\0';
+      if (overflowed) Serial.println("(prompt too long)");
+      else if (len) tell_story(line);
+      len = 0; overflowed = false;
+      Serial.println("READY>");
+    } else if (len == 0 && ((uint8_t)ch < 0x20 || (uint8_t)ch >= 0x80)) {
+      // Leading control or non-ASCII byte: line noise, not the prompt.
+    } else if (len < (int)sizeof(line) - 1) {
+      line[len++] = ch;
+    } else {
+      // Past the buffer. Keep consuming to the newline so the tail of an
+      // oversized line cannot be read as the beginning of the next one.
+      overflowed = true;
+    }
+  }
+  delay(5);
+}

--- a/firmware/esp32_tinystories/esp32_tinystories.ino
+++ b/firmware/esp32_tinystories/esp32_tinystories.ino
@@ -41,6 +41,54 @@
 #define LLM_DOT_S16V llm_pie_dot_s16v
 #endif
 #include "../../runtime/llm.h"
+#if CONFIG_IDF_TARGET_ESP32P4
+// The head is bound by PSRAM latency, not compute: ask the L1 data cache's
+// preload engine for the next block of rows while the current one computes.
+// One engine serves both cores, so requests are serialised with a spinlock
+// and a core waits for the engine to be idle before handing it a block.
+#include "esp32p4/rom/cache.h"
+// HEAD_PRELOAD: 0 none, 1 the L1 data cache engine (64 KB cache), 2 the L2
+// engine (256 KB cache). HEAD_PRELOAD_BYTES is the block requested ahead.
+#ifndef HEAD_PRELOAD
+#define HEAD_PRELOAD 1
+#endif
+#ifndef HEAD_PRELOAD_BYTES
+#define HEAD_PRELOAD_BYTES 8192
+#endif
+#if HEAD_PRELOAD == 1
+#define PRELOAD_DONE()          Cache_L1_DCache_Preload_Done()
+#define PRELOAD_START(a, n)     Cache_Start_L1_DCache_Preload((a), (n), 0)
+#define PRELOAD_END(auto_)      Cache_End_L1_DCache_Preload(auto_)
+#elif HEAD_PRELOAD == 2
+#define PRELOAD_DONE()          Cache_L2_Cache_Preload_Done()
+#define PRELOAD_START(a, n)     Cache_Start_L2_Cache_Preload((a), (n), 0)
+#define PRELOAD_END(auto_)      Cache_End_L2_Cache_Preload(auto_)
+#endif
+#if HEAD_PRELOAD
+static portMUX_TYPE preload_mux = portMUX_INITIALIZER_UNLOCKED;
+static uint32_t preload_autoload = 1;
+static inline void head_preload_start(const void *addr, size_t bytes) {
+  for (;;) {
+    portENTER_CRITICAL(&preload_mux);
+    if (PRELOAD_DONE()) {
+      preload_autoload = PRELOAD_START((uint32_t)(uintptr_t)addr, bytes);
+      portEXIT_CRITICAL(&preload_mux);
+      return;
+    }
+    portEXIT_CRITICAL(&preload_mux);
+  }
+}
+static inline void head_preload_end(void) {
+  while (!PRELOAD_DONE()) { }
+  portENTER_CRITICAL(&preload_mux);
+  PRELOAD_END(preload_autoload);
+  portEXIT_CRITICAL(&preload_mux);
+}
+#define LLM_PRELOAD_BYTES HEAD_PRELOAD_BYTES
+#define LLM_PRELOAD_START(addr, bytes) head_preload_start((addr), (bytes))
+#define LLM_PRELOAD_END() head_preload_end()
+#endif
+#endif
 #include "../../runtime/llm_pie.h"
 #include "../../runtime/bpe_tokenizer.h"
 #include "generated/vocab.h"
@@ -281,12 +329,12 @@ static void alloc_scratch() {
   // rather than spend a fifth of internal SRAM on it.
   s.logits = (float *)ps_or_die((size_t)model.out_vocab * 4, "logits");
 #ifdef LLM_KV_QUANT
-  // Quantized KV cache. The int8 keys (192 KB) are read for every position at
-  // every step, so they go to internal SRAM with the per-head temporaries;
-  // the int16 values and the scales (about 340 KB) stay in PSRAM.
+  // Quantized KV cache: keys, values and scales in PSRAM (the caches cover
+  // them well: keeping the keys in SRAM measured no gain, and the SRAM is
+  // better spent on the head's scale table), the per-head temporaries in SRAM.
   llm_kv_quant_bind(&model, &s,
-                    ps_or_die(llm_kv_main_bytes(&model), "kv values"),
-                    sram_or_die(llm_kv_key_bytes(&model), "kv keys"),
+                    ps_or_die(llm_kv_main_bytes(&model) + llm_kv_key_bytes(&model), "kv cache"),
+                    NULL,
                     sram_or_die(llm_kv_hot_bytes(&model), "kv temporaries"));
   s.kcache = s.vcache = NULL;
 #else
@@ -473,8 +521,10 @@ void setup() {
   // PSRAM bandwidth, so half the bytes is the win.
 #if LLM_HAVE_PIE
   if (model.out_head.cols % 32 == 0 && model.out_head.group % 32 == 0) {
-    void *b = ps_or_die(llm_stage_int4_bytes(&model.out_head), "staged head int4");
-    llm_stage_int4(&model.out_head, b);
+    // Codes in PSRAM; the per-row scales (100 KB) in SRAM, read once per row.
+    size_t code_bytes = (size_t)model.out_head.rows * model.out_head.row_bytes;
+    llm_stage_int4_split(&model.out_head, ps_or_die(code_bytes, "staged head int4"),
+                         sram_or_die(llm_stage_int4_scale_bytes(&model.out_head), "head scales"));
     ++staged;
   } else
 #endif
@@ -523,7 +573,11 @@ void setup() {
 #endif
   Serial.printf("sampling: temperature %.2f, top-k %d | matvec: %s | head: %s | kv cache: %s | attention: %s\n\n",
                 TEMPERATURE, TOP_K, LLM_HAVE_PIE ? "PIE vector" : "scalar",
+#ifdef LLM_PRELOAD_START
+                model.out_head.w4 ? "int4, vector unpack, cache preload" : "int8", kv_mode,
+#else
                 model.out_head.w4 ? "int4, vector unpack" : "int8", kv_mode,
+#endif
                 model.attn_heads ? "both cores" : "one core");
   Serial.println("type a story prompt and press return.");
   // A UART bridge can deliver a glitch byte around reset. Anything received

--- a/firmware/esp32_tinystories/esp32_tinystories.ino
+++ b/firmware/esp32_tinystories/esp32_tinystories.ino
@@ -117,10 +117,18 @@ static float job_xs;
 static float *job_y;
 static int job_split;
 
+#if LLM_HAVE_PIE
+// The head's activations in the layout the int4 kernel reads, built once per
+// matvec by quantize_shared (both cores read them).
+static int8_t xperm_shared[LLM_Q8_MAX_INPUT] __attribute__((aligned(16)));
+static int32_t xsum8_shared[LLM_Q8_MAX_INPUT / 32 + 1];
+#endif
+
 // Ranged int8 matvec for one staged tensor on the calling core.
 static void matvec_rows(const QT *t, const int8_t *xq, float xs, float *y,
                         int row_begin, int row_end) {
 #if LLM_HAVE_PIE
+  if (llm_pie4_ok(t)) { matvec_pie4_range(t, xperm_shared, xsum8_shared, xs, y, row_begin, row_end); return; }
   if (llm_pie_ok(t)) { matvec_pie_range(t, xq, xs, y, row_begin, row_end); return; }
 #endif
   matvec_i8_range(t, xq, xs, y, row_begin, row_end);
@@ -142,11 +150,14 @@ static float quantize_shared(const QT *t, const float *x) {
   float xs;
   quantize_act(x, t->cols, xq_shared, &xs);
   for (int j = t->cols; j < t->stride8; j++) xq_shared[j] = 0;
+#if LLM_HAVE_PIE
+  if (t->w4) llm_pie4_prepare(xq_shared, t->cols, t->group, xperm_shared, xsum8_shared);
+#endif
   return xs;
 }
 
 static void matvec_par(const QT *t, const float *x, float *y) {
-  if (t->w8 == NULL) { MATVEC(t, x, y); return; }
+  if (t->w8 == NULL && t->w4 == NULL) { MATVEC(t, x, y); return; }
   float xs = quantize_shared(t, x);      // once; both cores read the result
   if (t->rows < 128) { matvec_rows(t, xq_shared, xs, y, 0, t->rows); return; }
   job_t = t; job_xq = xq_shared; job_xs = xs; job_y = y; job_split = t->rows / 2;
@@ -166,12 +177,17 @@ static bool pie_self_check() {
   double worst = 0;
   for (unsigned c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
     const QT *t = cases[c];
-    if (!llm_pie_ok(t)) { Serial.printf("pie: tensor %u not eligible\n", c); return false; }
     for (int j = 0; j < t->cols; j++) x[j] = sinf(0.37f * j + c) * 1.7f;
     float xs = quantize_shared(t, x);
     int rows = t->rows < 1024 ? t->rows : 1024;
-    matvec_i8_range(t, xq_shared, xs, ref, 0, rows);
-    matvec_pie_range(t, xq_shared, xs, got, 0, rows);
+    if (llm_pie4_ok(t)) {
+      // int4 staging: the reference is the scalar walk of the same nibbles.
+      matvec_q8_range(t, xq_shared, xs, ref, 0, rows);
+      matvec_pie4_range(t, xperm_shared, xsum8_shared, xs, got, 0, rows);
+    } else if (llm_pie_ok(t)) {
+      matvec_i8_range(t, xq_shared, xs, ref, 0, rows);
+      matvec_pie_range(t, xq_shared, xs, got, 0, rows);
+    } else { Serial.printf("pie: tensor %u not eligible\n", c); return false; }
     for (int r = 0; r < rows; r++) {
       double d = fabs((double)ref[r] - got[r]);
       if (d > worst) worst = d;
@@ -424,7 +440,16 @@ void setup() {
     while (1) delay(1000);
   }
   // The tied head is read per token, not per position, so the core helper does
-  // not walk it. Stage it too: it is 85%% of the dense MACs.
+  // not walk it. Stage it too: it is 85%% of the dense MACs. With the vector
+  // unit it stays int4 and is unpacked in registers: the head is bound by
+  // PSRAM bandwidth, so half the bytes is the win.
+#if LLM_HAVE_PIE
+  if (model.out_head.cols % 32 == 0 && model.out_head.group % 32 == 0) {
+    void *b = ps_or_die(llm_stage_int4_bytes(&model.out_head), "staged head int4");
+    llm_stage_int4(&model.out_head, b);
+    ++staged;
+  } else
+#endif
   {
     void *b = ps_or_die(llm_stage_int8_bytes(&model.out_head), "staged head");
     llm_stage_int8(&model.out_head, b);
@@ -465,8 +490,9 @@ void setup() {
 #else
   const char *kv_mode = "fp32";
 #endif
-  Serial.printf("sampling: temperature %.2f, top-k %d | matvec: %s | kv cache: %s\n\n",
-                TEMPERATURE, TOP_K, LLM_HAVE_PIE ? "PIE vector" : "scalar", kv_mode);
+  Serial.printf("sampling: temperature %.2f, top-k %d | matvec: %s | head: %s | kv cache: %s\n\n",
+                TEMPERATURE, TOP_K, LLM_HAVE_PIE ? "PIE vector" : "scalar",
+                model.out_head.w4 ? "int4, vector unpack" : "int8", kv_mode);
   Serial.println("type a story prompt and press return.");
   // A UART bridge can deliver a glitch byte around reset. Anything received
   // before this point is not a prompt, so drop it rather than let it poison

--- a/firmware/esp32_tinystories/esp32_tinystories.ino
+++ b/firmware/esp32_tinystories/esp32_tinystories.ino
@@ -563,6 +563,12 @@ void setup() {
                   (unsigned)(sram_used + STATIC_SRAM_BYTES),
                   psram_used / 1048576.0);
   }
+#ifdef CPU_MHZ
+  // Requested explicitly, over the board file's F_CPU. The HAL reports whether
+  // it accepted the value; the line below shows what the chip actually runs.
+  Serial.printf("cpu: request %d MHz -> %s\n", CPU_MHZ, setCpuFrequencyMhz(CPU_MHZ) ? "accepted" : "rejected");
+#endif
+  Serial.printf("cpu: %u MHz, %d cores\n", (unsigned)getCpuFrequencyMhz(), (int)portNUM_PROCESSORS);
   Serial.printf("free: sram %.0f KB | psram %.2f MB\n",
                 heap_caps_get_free_size(MALLOC_CAP_INTERNAL) / 1024.0,
                 heap_caps_get_free_size(MALLOC_CAP_SPIRAM) / 1048576.0);

--- a/firmware/esp32_tinystories/esp32_tinystories.ino
+++ b/firmware/esp32_tinystories/esp32_tinystories.ino
@@ -34,6 +34,11 @@
 // vector kernel reads whole vectors; every other target keeps rows packed.
 #if CONFIG_IDF_TARGET_ESP32P4
 #define LLM_STAGE_ALIGN 16
+// Attention on the quantized KV cache, with both passes as PIE vector dots.
+#define LLM_KV_QUANT 1
+#include "../../runtime/llm_pie_dot.h"
+#define LLM_DOT_S8V  llm_pie_dot_s8v
+#define LLM_DOT_S16V llm_pie_dot_s16v
 #endif
 #include "../../runtime/llm.h"
 #include "../../runtime/llm_pie.h"
@@ -172,9 +177,28 @@ static bool pie_self_check() {
       if (d > worst) worst = d;
     }
   }
-  Serial.printf("pie self-check: max |vector - scalar| = %g -> %s\n", worst,
-                worst == 0 ? "ok" : "FAIL");
-  return worst == 0;
+  // The attention dots, including the 40-bit read of the int16 accumulator:
+  // extreme values first, then a pseudo-random fill, against the scalar sums.
+  static int8_t a8[256] __attribute__((aligned(16))), b8[256] __attribute__((aligned(16)));
+  static int16_t a16[256] __attribute__((aligned(16))), b16[256] __attribute__((aligned(16)));
+  int dot_bad = 0;
+  for (int pass = 0; pass < 2; pass++) {
+    uint32_t r = 0x9E3779B9u ^ pass;
+    for (int i = 0; i < 256; i++) {
+      r ^= r << 13; r ^= r >> 17; r ^= r << 5;
+      a8[i] = pass ? (int8_t)(r % 255) - 127 : (i & 1 ? 127 : -127);
+      b8[i] = pass ? (int8_t)((r >> 8) % 255) - 127 : 127;
+      a16[i] = pass ? (int16_t)(r % 65535) - 32767 : (i & 1 ? 32767 : -32767);
+      b16[i] = pass ? (int16_t)((r >> 16) % 65535) - 32767 : (i & 1 ? 32767 : 32767);
+    }
+    for (int nvec = 1; nvec <= 16; nvec++) {
+      if (llm_pie_dot_s8v(a8, b8, nvec) != llm_dot_s8v_scalar(a8, b8, nvec)) dot_bad++;
+      if (llm_pie_dot_s16v(a16, b16, nvec) != llm_dot_s16v_scalar(a16, b16, nvec)) dot_bad++;
+    }
+  }
+  Serial.printf("pie self-check: matvec max |vector - scalar| = %g, dot mismatches %d -> %s\n",
+                worst, dot_bad, (worst == 0 && dot_bad == 0) ? "ok" : "FAIL");
+  return worst == 0 && dot_bad == 0;
 }
 #endif
 
@@ -217,9 +241,15 @@ static void alloc_scratch() {
   // logits: out_vocab floats, 99 KiB here, read once per token. Left in PSRAM
   // rather than spend a fifth of internal SRAM on it.
   s.logits = (float *)ps_or_die((size_t)model.out_vocab * 4, "logits");
+#ifdef LLM_KV_QUANT
+  // Quantized KV cache: int8 keys, int16 transposed values, about 540 KB.
+  llm_kv_quant_bind(&model, &s, ps_or_die(llm_kv_quant_bytes(&model), "kv cache"));
+  s.kcache = s.vcache = NULL;
+#else
   // KV cache: 1.1MB, read once per position rather than per matvec.
   s.kcache = (float *)ps_or_die((size_t)L * S * D * 4, "kcache");
   s.vcache = (float *)ps_or_die((size_t)L * S * D * 4, "vcache");
+#endif
 }
 
 static void blink(uint8_t g) {
@@ -430,8 +460,13 @@ void setup() {
   Serial.printf("free: sram %.0f KB | psram %.2f MB\n",
                 heap_caps_get_free_size(MALLOC_CAP_INTERNAL) / 1024.0,
                 heap_caps_get_free_size(MALLOC_CAP_SPIRAM) / 1048576.0);
-  Serial.printf("sampling: temperature %.2f, top-k %d | matvec kernel: %s\n\n",
-                TEMPERATURE, TOP_K, LLM_HAVE_PIE ? "PIE vector" : "scalar");
+#ifdef LLM_KV_QUANT
+  const char *kv_mode = "int8 keys / int16 values, vector dots";
+#else
+  const char *kv_mode = "fp32";
+#endif
+  Serial.printf("sampling: temperature %.2f, top-k %d | matvec: %s | kv cache: %s\n\n",
+                TEMPERATURE, TOP_K, LLM_HAVE_PIE ? "PIE vector" : "scalar", kv_mode);
   Serial.println("type a story prompt and press return.");
   // A UART bridge can deliver a glitch byte around reset. Anything received
   // before this point is not a prompt, so drop it rather than let it poison

--- a/firmware/esp32_tinystories/esp32_tinystories.ino
+++ b/firmware/esp32_tinystories/esp32_tinystories.ino
@@ -116,6 +116,10 @@ static const int8_t *job_xq;
 static float job_xs;
 static float *job_y;
 static int job_split;
+// Attention job: the worker takes heads [0, job_h) of layer job_l at job_pos.
+static int job_l, job_pos, job_h;
+enum { JOB_MATVEC, JOB_ATTN };
+static int job_kind = JOB_MATVEC;
 
 #if LLM_HAVE_PIE
 // The head's activations in the layout the int4 kernel reads, built once per
@@ -137,10 +141,29 @@ static void matvec_rows(const QT *t, const int8_t *xq, float xs, float *y,
 static void worker_main(void *) {
   for (;;) {
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-    matvec_rows(job_t, job_xq, job_xs, job_y, 0, job_split);
+#ifdef LLM_KV_QUANT
+    if (job_kind == JOB_ATTN)
+      llm_attend_heads(&model, &s, job_l, job_pos, 0, job_h, s.q8b, s.w16b, s.scoresb);
+    else
+#endif
+      matvec_rows(job_t, job_xq, job_xs, job_y, 0, job_split);
     xTaskNotifyGive(main_h);
   }
 }
+
+#ifdef LLM_KV_QUANT
+// Heads are independent: the worker core takes the first half with its own
+// temporaries while this core takes the rest, each writing its own slice of
+// s.att.
+static void attn_par(Model *m, Scratch *sc, int l, int pos) {
+  int H = m->c.n_heads;
+  job_kind = JOB_ATTN; job_l = l; job_pos = pos; job_h = H / 2;
+  xTaskNotifyGive(worker_h);
+  llm_attend_heads(m, sc, l, pos, H / 2, H, sc->q8, sc->w16, sc->scores);
+  ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+  job_kind = JOB_MATVEC;
+}
+#endif
 
 // Quantize x into the shared activation buffer. The vector kernel reads the
 // row's padded width, so the bytes past cols are cleared every call: the
@@ -467,6 +490,9 @@ void setup() {
     // After the worker exists: matvec_par notifies worker_h.
     model.layer_matvec = matvec_par;
     model.head_matvec  = matvec_par;
+#ifdef LLM_KV_QUANT
+    model.attn_heads = attn_par;
+#endif
   } else {
     Serial.println("dual-core worker failed; running single core");
   }
@@ -490,9 +516,10 @@ void setup() {
 #else
   const char *kv_mode = "fp32";
 #endif
-  Serial.printf("sampling: temperature %.2f, top-k %d | matvec: %s | head: %s | kv cache: %s\n\n",
+  Serial.printf("sampling: temperature %.2f, top-k %d | matvec: %s | head: %s | kv cache: %s | attention: %s\n\n",
                 TEMPERATURE, TOP_K, LLM_HAVE_PIE ? "PIE vector" : "scalar",
-                model.out_head.w4 ? "int4, vector unpack" : "int8", kv_mode);
+                model.out_head.w4 ? "int4, vector unpack" : "int8", kv_mode,
+                model.attn_heads ? "both cores" : "one core");
   Serial.println("type a story prompt and press return.");
   // A UART bridge can deliver a glitch byte around reset. Anything received
   // before this point is not a prompt, so drop it rather than let it poison

--- a/firmware/esp32_tinystories/tools/generate_tokenizer_header.py
+++ b/firmware/esp32_tinystories/tools/generate_tokenizer_header.py
@@ -1,0 +1,41 @@
+"""Build this sketch's encoder header from its tokenizer.
+
+Writes generated/tokenizer_encoder.h: the BTK1 asset runtime/bpe_tokenizer.h
+loads, so a prompt typed over serial is encoded on the device with the same
+ByteLevel BPE the model was trained with.
+
+The packer itself lives with Barista, which introduced the on-device encoder;
+this is that tool pointed at the TinyStories tokenizer. The one difference is
+<|endoftext|>, a special added token: the model emits it to end a story, and
+a user never has to type it, so the packer is told to accept it.
+
+  uv run python firmware/esp32_tinystories/tools/generate_tokenizer_header.py
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+SKETCH = Path(__file__).resolve().parent.parent
+ROOT = SKETCH.parent.parent
+DEFAULT_TOKENIZER = ROOT / "artifacts" / "tinystories" / "tokenizer.json"
+DEFAULT_OUT = SKETCH / "generated" / "tokenizer_encoder.h"
+
+sys.path.insert(0, str(ROOT / "firmware" / "esp32_barista" / "tools"))
+from generate_tokenizer_header import generate  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Pack the TinyStories BPE encoder tables into a C header.")
+    ap.add_argument("--tokenizer", default=DEFAULT_TOKENIZER,
+                    help="canonical tokenizer.json the asset is built from")
+    ap.add_argument("--out", default=DEFAULT_OUT, help="header to write")
+    ap.add_argument("--asset", default=None,
+                    help="also write the raw BTK1 bytes here, for host checks")
+    args = ap.parse_args()
+    generate(args.tokenizer, args.out, args.asset, allow_special_added_tokens=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/runtime/host_verify/ppl.c
+++ b/runtime/host_verify/ppl.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
   s.logits = malloc(V*4); s.scores = malloc(S*4);
   s.kcache = malloc((size_t)L*S*D*4); s.vcache = malloc((size_t)L*S*D*4);
 #ifdef LLM_KV_QUANT
-  llm_kv_quant_bind(&m, &s, malloc(llm_kv_quant_bytes(&m)));
+  llm_kv_quant_bind(&m, &s, malloc(llm_kv_quant_bytes(&m)), NULL, NULL);
 #endif
 
   size_t vn; uint16_t *val = (uint16_t *)read_file(valp, &vn);

--- a/runtime/host_verify/ppl.c
+++ b/runtime/host_verify/ppl.c
@@ -38,6 +38,9 @@ int main(int argc, char **argv) {
   s.ple = malloc(L*P*4); s.tmpP = malloc(L*P*4); s.trow = malloc(L*P*4);
   s.logits = malloc(V*4); s.scores = malloc(S*4);
   s.kcache = malloc((size_t)L*S*D*4); s.vcache = malloc((size_t)L*S*D*4);
+#ifdef LLM_KV_QUANT
+  llm_kv_quant_bind(&m, &s, malloc(llm_kv_quant_bytes(&m)));
+#endif
 
   size_t vn; uint16_t *val = (uint16_t *)read_file(valp, &vn);
   size_t n_tok = vn / 2;
@@ -64,6 +67,9 @@ int main(int argc, char **argv) {
   const char *mode = "int8-activations";
 #else
   const char *mode = "fp32-activations";
+#endif
+#ifdef LLM_KV_QUANT
+  mode = "int8-act + quant-KV";
 #endif
   printf("%-18s  val CE %.4f  ppl %.2f   (%ld predictions)\n",
          mode, mean, exp(mean), count);

--- a/runtime/llm.h
+++ b/runtime/llm.h
@@ -39,9 +39,23 @@ typedef struct {
   /* Optional int8 staging: nibbles unpacked and group scales converted once, so
    * each matvec skips both. Numerics are unchanged - same codes, same scales,
    * same group sums. NULL selects the int4 path. */
-  const int8_t *w8;        // rows*cols, values -7..7
+  const int8_t *w8;        // rows*stride8, values -7..7; padding bytes are 0
   const float  *scale8;    // rows*n_groups, half2float'd once
+  int stride8;             // bytes per staged row: cols rounded up to
+                           // LLM_STAGE_ALIGN, so a SIMD kernel can read whole
+                           // vectors without a tail case
 } QT;
+
+/* Staged rows are padded to this many bytes. 1 keeps rows contiguous, which
+ * is what the host verifier and the scalar kernel need nothing more than; a
+ * platform with 16-byte vector loads defines 16 before including this file
+ * and allocates staging buffers with matching alignment. */
+#ifndef LLM_STAGE_ALIGN
+#define LLM_STAGE_ALIGN 1
+#endif
+static inline int llm_stage_stride(int cols) {
+  return (cols + LLM_STAGE_ALIGN - 1) / LLM_STAGE_ALIGN * LLM_STAGE_ALIGN;
+}
 
 // IEEE half -> float.
 static inline float half2float(uint16_t h) {
@@ -98,6 +112,7 @@ static const uint8_t *bind_q(const uint8_t *p, QT *t, int rows, int cols) {
   t->codes = p;  p += (size_t)rows * t->row_bytes;
   t->scales = (const uint16_t *)p;  p += (size_t)rows * t->n_groups * 2;
   t->w8 = NULL; t->scale8 = NULL;   // int4 path until staged
+  t->stride8 = 0;
   return p;
 }
 static const uint8_t *bind_f(const uint8_t *p, const float **t, int n) {
@@ -225,9 +240,9 @@ __attribute__((noinline))
 #endif
 static void matvec_i8_range(const QT *t, const int8_t *xq, float x_scale,
                             float *y, int row_begin, int row_end) {
-  int g = t->group, ng = t->n_groups, cols = t->cols;
+  int g = t->group, ng = t->n_groups, cols = t->cols, stride = t->stride8;
   for (int r = row_begin; r < row_end; r++) {
-    const int8_t *w = t->w8 + (size_t)r * cols;
+    const int8_t *w = t->w8 + (size_t)r * stride;
     const float *sc = t->scale8 + (size_t)r * ng;
     float acc = 0.f;
     for (int gi = 0; gi < ng; gi++) {
@@ -358,7 +373,7 @@ static int llm_load(const uint8_t *base, Model *m) {
 /* Byte offset of the float scale array in a staged buffer. rows*cols need not
  * be a multiple of 4, so the offset is rounded up to keep the float* aligned. */
 static inline size_t llm_stage_scale_offset(const QT *t) {
-  size_t w_bytes = (size_t)t->rows * t->cols * sizeof(int8_t);
+  size_t w_bytes = (size_t)t->rows * llm_stage_stride(t->cols) * sizeof(int8_t);
   return (w_bytes + sizeof(float) - 1) & ~(size_t)(sizeof(float) - 1);
 }
 
@@ -370,20 +385,23 @@ static inline size_t llm_stage_int8_bytes(const QT *t) {
 static inline void llm_stage_int8(QT *t, void *buffer) {
   int8_t *w = (int8_t *)buffer;
   float *sc = (float *)((uint8_t *)buffer + llm_stage_scale_offset(t));
+  int stride = llm_stage_stride(t->cols);
   for (int r = 0; r < t->rows; r++) {
     const uint8_t *row = t->codes + (size_t)r * t->row_bytes;
-    int8_t *dst = w + (size_t)r * t->cols;
+    int8_t *dst = w + (size_t)r * stride;
     for (int j = 0; j < t->cols; j++) {
       uint8_t byte = row[j >> 1];
       int code = (j & 1) ? (byte >> 4) : (byte & 0xF);
       dst[j] = (int8_t)(code - 8);
     }
+    for (int j = t->cols; j < stride; j++) dst[j] = 0;
     for (int gi = 0; gi < t->n_groups; gi++)
       sc[(size_t)r * t->n_groups + gi] =
           half2float(t->scales[(size_t)r * t->n_groups + gi]);
   }
   t->w8 = w;
   t->scale8 = sc;
+  t->stride8 = stride;
 }
 
 /* Stage every per-position tensor, one allocation per tensor: a multi-megabyte

--- a/runtime/llm.h
+++ b/runtime/llm.h
@@ -543,28 +543,49 @@ static void llm_profile_reset(Scratch *s) {
 #endif
 
 #ifdef LLM_KV_QUANT
-/* One allocation holds every quantized-cache buffer; the caller places it
- * (host: malloc, device: PSRAM or SRAM). Sized with slack for alignment. */
-static inline size_t llm_kv_quant_bytes(const Model *m) {
-  size_t L = m->c.n_layers, S = m->c.seq_len, H = m->c.n_heads, Dh = m->c.dim / m->c.n_heads;
-  return L * S * H * LLM_KPAD + L * H * Dh * S * sizeof(int16_t)
-       + 2 * L * S * H * sizeof(float)
-       + 2 * (LLM_KPAD + S * sizeof(int16_t)) + S * sizeof(float) + 96;
+/* The quantized cache is three placements, because they are read at very
+ * different rates and a device can afford fast memory for the small ones:
+ *   key   the int8 keys, one 32-byte row per position and head: read for
+ *         every position at every step, the hottest part of the cache;
+ *   hot   the per-head temporaries (two sets, for two cores);
+ *   main  the transposed int16 values and both scale arrays.
+ * llm_kv_quant_bind takes a buffer for each; a NULL key or hot buffer is
+ * carved out of main instead, in which case main must be sized with
+ * llm_kv_quant_bytes (the sum of all three). Sizes include alignment slack. */
+static inline size_t llm_kv_key_bytes(const Model *m) {
+  return (size_t)m->c.n_layers * m->c.seq_len * m->c.n_heads * LLM_KPAD + 16;
 }
-static inline void llm_kv_quant_bind(const Model *m, Scratch *s, void *buffer) {
+static inline size_t llm_kv_hot_bytes(const Model *m) {
+  size_t S = m->c.seq_len;
+  return 2 * (LLM_KPAD + S * sizeof(int16_t)) + S * sizeof(float) + 48;
+}
+static inline size_t llm_kv_main_bytes(const Model *m) {
   size_t L = m->c.n_layers, S = m->c.seq_len, H = m->c.n_heads, Dh = m->c.dim / m->c.n_heads;
-  uint8_t *p = (uint8_t *)(((uintptr_t)buffer + 15) & ~(uintptr_t)15);
-  s->k8 = (int8_t *)p;    p += L * S * H * LLM_KPAD;           /* 32-byte rows */
+  return L * H * Dh * S * sizeof(int16_t) + 2 * L * S * H * sizeof(float) + 16;
+}
+static inline size_t llm_kv_quant_bytes(const Model *m) {
+  return llm_kv_main_bytes(m) + llm_kv_key_bytes(m) + llm_kv_hot_bytes(m);
+}
+static inline uint8_t *llm_align16(void *p) {
+  return (uint8_t *)(((uintptr_t)p + 15) & ~(uintptr_t)15);
+}
+static inline void llm_kv_quant_bind(const Model *m, Scratch *s, void *main_buf,
+                                     void *key_buf, void *hot_buf) {
+  size_t L = m->c.n_layers, S = m->c.seq_len, H = m->c.n_heads, Dh = m->c.dim / m->c.n_heads;
+  uint8_t *p = llm_align16(main_buf);
   s->v16t = (int16_t *)p; p += L * H * Dh * S * sizeof(int16_t); /* S*2-byte rows */
   s->ks = (float *)p;     p += L * S * H * sizeof(float);
   s->vs = (float *)p;     p += L * S * H * sizeof(float);
-  p = (uint8_t *)(((uintptr_t)p + 15) & ~(uintptr_t)15);
-  s->q8 = (int8_t *)p;    p += LLM_KPAD;
-  s->w16 = (int16_t *)p;  p += S * sizeof(int16_t);
-  p = (uint8_t *)(((uintptr_t)p + 15) & ~(uintptr_t)15);
-  s->q8b = (int8_t *)p;   p += LLM_KPAD;
-  s->w16b = (int16_t *)p; p += S * sizeof(int16_t);
-  s->scoresb = (float *)p;
+  uint8_t *k = llm_align16(key_buf ? key_buf : p);
+  s->k8 = (int8_t *)k;    k += L * S * H * LLM_KPAD;              /* 32-byte rows */
+  if (!key_buf) p = k;
+  uint8_t *h = llm_align16(hot_buf ? hot_buf : p);
+  s->q8 = (int8_t *)h;    h += LLM_KPAD;
+  s->w16 = (int16_t *)h;  h += S * sizeof(int16_t);
+  h = llm_align16(h);
+  s->q8b = (int8_t *)h;   h += LLM_KPAD;
+  s->w16b = (int16_t *)h; h += S * sizeof(int16_t);
+  s->scoresb = (float *)h;
 }
 
 /* Attention over heads h0..h1-1 of one layer at one position, on the

--- a/runtime/llm.h
+++ b/runtime/llm.h
@@ -81,7 +81,10 @@ static inline float half2float(uint16_t h) {
   float out; memcpy(&out, &f, 4); return out;
 }
 
-typedef struct {
+struct Scratch;
+typedef struct Model Model;
+
+struct Model {
   Cfg c;
   QT tok_emb;             // [V, D]  input embedding
   QT out_head;            // [Vout, D]; first Vout rows of tok_emb when tied
@@ -105,7 +108,12 @@ typedef struct {
   // tied 32,768-row head and a 66-row FFN matrix have different cost profiles.
   void (*head_matvec)(const QT *, const float *, float *);
   void (*layer_matvec)(const QT *, const float *, float *);
-} Model;
+  /* Attention for one layer at one position over all heads, on the quantized
+   * KV path only. NULL runs the heads in sequence on the calling core; a
+   * platform can split them across cores with llm_attend_heads and the
+   * second scratch set (q8b, w16b, scoresb). */
+  void (*attn_heads)(Model *, struct Scratch *, int layer, int pos);
+};
 
 // Advance a cursor over the file, binding one quant tensor. Reads the per-tensor
 // group prefix, then ragged codes + fp16 scales.
@@ -383,6 +391,7 @@ static int llm_load(const uint8_t *base, Model *m) {
 
   m->head_matvec = NULL;
   m->layer_matvec = NULL;
+  m->attn_heads = NULL;
   int D = m->c.dim, L = m->c.n_layers, P = m->c.ple_dim, F = m->c.ffn, V = m->c.vocab;
 
   p = bind_q(p, &m->tok_emb, V, D);
@@ -504,7 +513,7 @@ static inline int llm_core_stage_count(const Model *m) {
 }
 
 // Scratch buffers, caller-allocated (host: malloc; device: PSRAM).
-typedef struct {
+typedef struct Scratch {
   float *x, *h, *qkv, *att, *g1, *g2, *ple, *tmpP, *trow, *logits;
   float *scores; // [seq_len], reused by each attention head
   float *kcache, *vcache; // [L * seq_len * D]; unused under LLM_KV_QUANT
@@ -515,6 +524,9 @@ typedef struct {
   float   *vs;    // [L][S][H] value scales
   int8_t  *q8;    // [LLM_KPAD] this head's query, 16-byte aligned
   int16_t *w16;   // [S] this head's softmax weights, 16-byte aligned
+  int8_t  *q8b;   // second set of the three, for a second core
+  int16_t *w16b;
+  float   *scoresb; // [S]
 #endif
 #ifdef LLM_PROFILE
   struct {
@@ -536,7 +548,8 @@ static void llm_profile_reset(Scratch *s) {
 static inline size_t llm_kv_quant_bytes(const Model *m) {
   size_t L = m->c.n_layers, S = m->c.seq_len, H = m->c.n_heads, Dh = m->c.dim / m->c.n_heads;
   return L * S * H * LLM_KPAD + L * H * Dh * S * sizeof(int16_t)
-       + 2 * L * S * H * sizeof(float) + LLM_KPAD + S * sizeof(int16_t) + 64;
+       + 2 * L * S * H * sizeof(float)
+       + 2 * (LLM_KPAD + S * sizeof(int16_t)) + S * sizeof(float) + 96;
 }
 static inline void llm_kv_quant_bind(const Model *m, Scratch *s, void *buffer) {
   size_t L = m->c.n_layers, S = m->c.seq_len, H = m->c.n_heads, Dh = m->c.dim / m->c.n_heads;
@@ -547,7 +560,62 @@ static inline void llm_kv_quant_bind(const Model *m, Scratch *s, void *buffer) {
   s->vs = (float *)p;     p += L * S * H * sizeof(float);
   p = (uint8_t *)(((uintptr_t)p + 15) & ~(uintptr_t)15);
   s->q8 = (int8_t *)p;    p += LLM_KPAD;
-  s->w16 = (int16_t *)p;
+  s->w16 = (int16_t *)p;  p += S * sizeof(int16_t);
+  p = (uint8_t *)(((uintptr_t)p + 15) & ~(uintptr_t)15);
+  s->q8b = (int8_t *)p;   p += LLM_KPAD;
+  s->w16b = (int16_t *)p; p += S * sizeof(int16_t);
+  s->scoresb = (float *)p;
+}
+
+/* Attention over heads h0..h1-1 of one layer at one position, on the
+ * quantized cache, with the caller's temporaries. Reads k8/v16t written for
+ * every position up to pos, writes only this range's slice of s->att, so two
+ * ranges can run at once on two cores with separate temporaries. */
+static void llm_attend_heads(Model *m, Scratch *s, int l, int pos, int h0, int h1,
+                             int8_t *q8, int16_t *w16, float *scores) {
+  int D = m->c.dim, H = m->c.n_heads, Dh = D / H, S = m->c.seq_len;
+  float scale = 1.f / sqrtf((float)Dh);
+  int nk = LLM_KPAD / 16, n16 = (pos + 1 + 7) / 8;
+  const float *q = s->qkv;
+  for (int hh = h0; hh < h1; hh++) {
+    const float *qh = q + hh * Dh;
+    float *ao = s->att + hh * Dh;
+    float qmax = 1e-8f;
+    for (int i = 0; i < Dh; i++) { float a = fabsf(qh[i]); if (a > qmax) qmax = a; }
+    float qinv = 127.f / qmax;
+    for (int i = 0; i < Dh; i++) {
+      int v8 = (int)lrintf(qh[i] * qinv);
+      q8[i] = (int8_t)(v8 > 127 ? 127 : (v8 < -127 ? -127 : v8));
+    }
+    for (int i = Dh; i < LLM_KPAD; i++) q8[i] = 0;
+    float qs = qmax / 127.f * scale;
+    const int8_t *kb = s->k8 + ((size_t)l * S * H + hh) * LLM_KPAD;
+    const float *ksb = s->ks + (size_t)l * S * H + hh;
+    const float *vsb = s->vs + (size_t)l * S * H + hh;
+    float maxs = -1e30f;
+    for (int t = 0; t <= pos; t++) {
+      float dot = (float)LLM_DOT_S8V(q8, kb + (size_t)t * H * LLM_KPAD, nk)
+                  * qs * ksb[(size_t)t * H];
+      scores[t] = dot;
+      if (dot > maxs) maxs = dot;
+    }
+    // softmax weights, each multiplied by its position's value scale, to int16
+    float denom = 0.f, wmax = 0.f;
+    for (int t = 0; t <= pos; t++) {
+      float w = expf(scores[t] - maxs);
+      denom += w;
+      float wv = w * vsb[(size_t)t * H];
+      scores[t] = wv;
+      if (wv > wmax) wmax = wv;
+    }
+    float winv = 32767.f / wmax;
+    for (int t = 0; t <= pos; t++) w16[t] = (int16_t)lrintf(scores[t] * winv);
+    for (int t = pos + 1; t < n16 * 8; t++) w16[t] = 0;
+    float os = wmax / 32767.f / denom;
+    const int16_t *vt = s->v16t + ((size_t)l * H + hh) * Dh * S;
+    for (int i = 0; i < Dh; i++)
+      ao[i] = (float)LLM_DOT_S16V(vt + (size_t)i * S, w16, n16) * os;
+  }
 }
 #endif
 
@@ -607,7 +675,6 @@ static void llm_forward(Model *m, int token, int pos, Scratch *s) {
         kh[i] = k1 * c - k2 * sn; kh[i + Dh / 2] = k2 * c + k1 * sn;
       }
     }
-    float scale = 1.f / sqrtf((float)Dh);
 #ifdef LLM_KV_QUANT
     // ---- quantized cache: store this position's k (int8) and v (int16)
     for (int hh = 0; hh < H; hh++) {
@@ -635,50 +702,14 @@ static void llm_forward(Model *m, int token, int pos, Scratch *s) {
       s->vs[slot] = vmax / 32767.f;
     }
     // ---- causal attention over 0..pos, both passes as vector dots
-    int nk = LLM_KPAD / 16, n16 = (pos + 1 + 7) / 8;
-    for (int hh = 0; hh < H; hh++) {
-      float *qh = q + hh * Dh, *ao = s->att + hh * Dh;
-      float qmax = 1e-8f;
-      for (int i = 0; i < Dh; i++) { float a = fabsf(qh[i]); if (a > qmax) qmax = a; }
-      float qinv = 127.f / qmax;
-      for (int i = 0; i < Dh; i++) {
-        int q8 = (int)lrintf(qh[i] * qinv);
-        s->q8[i] = (int8_t)(q8 > 127 ? 127 : (q8 < -127 ? -127 : q8));
-      }
-      for (int i = Dh; i < LLM_KPAD; i++) s->q8[i] = 0;
-      float qs = qmax / 127.f * scale;
-      const int8_t *kb = s->k8 + ((size_t)l * S * H + hh) * LLM_KPAD;
-      const float *ksb = s->ks + (size_t)l * S * H + hh;
-      const float *vsb = s->vs + (size_t)l * S * H + hh;
-      float maxs = -1e30f;
-      for (int t = 0; t <= pos; t++) {
-        float dot = (float)LLM_DOT_S8V(s->q8, kb + (size_t)t * H * LLM_KPAD, nk)
-                    * qs * ksb[(size_t)t * H];
-        s->scores[t] = dot;
-        if (dot > maxs) maxs = dot;
-      }
-      // softmax weights, each multiplied by its position's value scale, to int16
-      float denom = 0.f, wmax = 0.f;
-      for (int t = 0; t <= pos; t++) {
-        float w = expf(s->scores[t] - maxs);
-        denom += w;
-        float wv = w * vsb[(size_t)t * H];
-        s->scores[t] = wv;
-        if (wv > wmax) wmax = wv;
-      }
-      float winv = 32767.f / wmax;
-      for (int t = 0; t <= pos; t++) s->w16[t] = (int16_t)lrintf(s->scores[t] * winv);
-      for (int t = pos + 1; t < n16 * 8; t++) s->w16[t] = 0;
-      float os = wmax / 32767.f / denom;
-      const int16_t *vt = s->v16t + ((size_t)l * H + hh) * Dh * S;
-      for (int i = 0; i < Dh; i++)
-        ao[i] = (float)LLM_DOT_S16V(vt + (size_t)i * S, s->w16, n16) * os;
-    }
+    if (m->attn_heads) m->attn_heads(m, s, l, pos);
+    else llm_attend_heads(m, s, l, pos, 0, H, s->q8, s->w16, s->scores);
 #else
     float *kc = s->kcache + (size_t)l * S * D, *vc = s->vcache + (size_t)l * S * D;
     memcpy(kc + (size_t)pos * D, k, D * sizeof(float));
     memcpy(vc + (size_t)pos * D, v, D * sizeof(float));
     // causal attention over 0..pos
+    float scale = 1.f / sqrtf((float)Dh);
     for (int hh = 0; hh < H; hh++) {
       float *qh = q + hh * Dh;
       float *ao = s->att + hh * Dh;

--- a/runtime/llm.h
+++ b/runtime/llm.h
@@ -471,6 +471,22 @@ static inline size_t llm_stage_int4_bytes(const QT *t) {
   return ((w_bytes + sizeof(float) - 1) & ~(size_t)(sizeof(float) - 1))
        + (size_t)t->rows * t->n_groups * sizeof(float);
 }
+/* The scales alone, so they can be placed apart from the codes (they are
+ * read once per row, and are small enough for fast memory). */
+static inline size_t llm_stage_int4_scale_bytes(const QT *t) {
+  return (size_t)t->rows * t->n_groups * sizeof(float);
+}
+static inline void llm_stage_int4_split(QT *t, void *codes_buf, void *scales_buf) {
+  size_t w_bytes = (size_t)t->rows * t->row_bytes;
+  uint8_t *w = (uint8_t *)codes_buf;
+  float *sc = (float *)scales_buf;
+  memcpy(w, t->codes, w_bytes);
+  for (size_t i = 0; i < (size_t)t->rows * t->n_groups; i++)
+    sc[i] = half2float(t->scales[i]);
+  t->w4 = w;
+  t->stride4 = t->row_bytes;
+  t->scale8 = sc;
+}
 static inline void llm_stage_int4(QT *t, void *buffer) {
   size_t w_bytes = (size_t)t->rows * t->row_bytes;
   uint8_t *w = (uint8_t *)buffer;

--- a/runtime/llm.h
+++ b/runtime/llm.h
@@ -44,6 +44,11 @@ typedef struct {
   int stride8;             // bytes per staged row: cols rounded up to
                            // LLM_STAGE_ALIGN, so a SIMD kernel can read whole
                            // vectors without a tail case
+  /* Optional int4 staging: the packed nibbles copied as they are, with the
+   * group scales converted once. Half the bytes of int8 staging, for a
+   * kernel that unpacks nibbles in registers. NULL unless staged this way. */
+  const uint8_t *w4;       // rows*stride4 packed nibbles, same layout as codes
+  int stride4;             // bytes per staged row, = row_bytes
 } QT;
 
 /* Staged rows are padded to this many bytes. 1 keeps rows contiguous, which
@@ -113,6 +118,7 @@ static const uint8_t *bind_q(const uint8_t *p, QT *t, int rows, int cols) {
   t->scales = (const uint16_t *)p;  p += (size_t)rows * t->n_groups * 2;
   t->w8 = NULL; t->scale8 = NULL;   // int4 path until staged
   t->stride8 = 0;
+  t->w4 = NULL; t->stride4 = 0;
   return p;
 }
 static const uint8_t *bind_f(const uint8_t *p, const float **t, int n) {
@@ -445,6 +451,28 @@ static inline void llm_stage_int8(QT *t, void *buffer) {
   t->w8 = w;
   t->scale8 = sc;
   t->stride8 = stride;
+}
+
+/* ---- int4 staging -----------------------------------------------------
+ * A straight copy of the packed codes out of flash into faster memory, plus
+ * float scales. The bytes are the same nibbles matvec_q8_range reads, so that
+ * function stays the scalar reference for any kernel using this staging. */
+static inline size_t llm_stage_int4_bytes(const QT *t) {
+  size_t w_bytes = (size_t)t->rows * t->row_bytes;
+  return ((w_bytes + sizeof(float) - 1) & ~(size_t)(sizeof(float) - 1))
+       + (size_t)t->rows * t->n_groups * sizeof(float);
+}
+static inline void llm_stage_int4(QT *t, void *buffer) {
+  size_t w_bytes = (size_t)t->rows * t->row_bytes;
+  uint8_t *w = (uint8_t *)buffer;
+  float *sc = (float *)((uint8_t *)buffer
+                        + ((w_bytes + sizeof(float) - 1) & ~(size_t)(sizeof(float) - 1)));
+  memcpy(w, t->codes, w_bytes);
+  for (size_t i = 0; i < (size_t)t->rows * t->n_groups; i++)
+    sc[i] = half2float(t->scales[i]);
+  t->w4 = w;
+  t->stride4 = t->row_bytes;
+  t->scale8 = sc;
 }
 
 /* Stage every per-position tensor, one allocation per tensor: a multi-megabyte

--- a/runtime/llm.h
+++ b/runtime/llm.h
@@ -231,6 +231,46 @@ static inline int32_t llm_dot_i8(const int8_t *a, const int8_t *b, int n) {
   return acc;
 }
 
+/* ---- vector dot primitives --------------------------------------------------
+ * Dot products over whole 16-byte vectors: nvec*16 int8 pairs, or nvec*8 int16
+ * pairs, exact integer sums. These scalar versions are the reference; a
+ * platform with a vector unit defines LLM_DOT_S8V / LLM_DOT_S16V to its own
+ * before including this file. The int16 sum needs more than 32 bits. */
+static inline int32_t llm_dot_s8v_scalar(const int8_t *a, const int8_t *b, int nvec) {
+  int32_t acc = 0;
+  for (int i = 0; i < nvec * 16; i++) acc += (int32_t)a[i] * (int32_t)b[i];
+  return acc;
+}
+static inline int64_t llm_dot_s16v_scalar(const int16_t *a, const int16_t *b, int nvec) {
+  int64_t acc = 0;
+  for (int i = 0; i < nvec * 8; i++) acc += (int64_t)a[i] * (int64_t)b[i];
+  return acc;
+}
+#ifndef LLM_DOT_S8V
+#define LLM_DOT_S8V llm_dot_s8v_scalar
+#endif
+#ifndef LLM_DOT_S16V
+#define LLM_DOT_S16V llm_dot_s16v_scalar
+#endif
+
+/* ---- quantized KV cache ------------------------------------------------------
+ * Optional attention path, selected by LLM_KV_QUANT. Keys are int8 with one
+ * scale per position and head, each head padded to LLM_KPAD bytes so a key is
+ * whole vectors. Values are int16 with one scale per position and head, stored
+ * TRANSPOSED: per layer, head and feature, one row over positions. Both
+ * attention passes then become the same integer dot products as the matvec:
+ *   score_t = q8 . k8_t              (one dot per position)
+ *   out_i   = v16t_i . w16           (one dot per feature over positions)
+ * The softmax weight of each position is multiplied by that position's value
+ * scale before it is quantized to int16, which is what lets the value scale
+ * vary per position while the dot product still sees a single scale.
+ * Bytes read per token drop about 3x against the fp32 cache and the MACs move
+ * to the vector unit. Quality is measured on the host with ppl.c, since the
+ * arithmetic here is exactly what the device runs. */
+#ifdef LLM_KV_QUANT
+#define LLM_KPAD 32     /* bytes per head in the key cache; head_dim <= 32 */
+#endif
+
 /* Same arithmetic as matvec_q8_range, reading pre-unpacked int8 weights.
  *
  * Keep out of line on ESP32-S3: with Arduino ESP32 3.3.10 at -O3, inlining
@@ -321,6 +361,9 @@ static int llm_load(const uint8_t *base, Model *m) {
       m->c.n_heads <= 0 || m->c.dim % m->c.n_heads != 0 ||
       (m->c.dim / m->c.n_heads) % 2 != 0)
     return -2;
+#ifdef LLM_KV_QUANT
+  if (m->c.dim / m->c.n_heads > LLM_KPAD) return -2;
+#endif
   /* A tied head is a view of the first out_vocab embedding rows, so it cannot
    * be longer than the embedding. */
   if ((flags & LLM_FLAG_TIED_HEAD) && m->out_vocab > m->c.vocab) return -2;
@@ -436,7 +479,15 @@ static inline int llm_core_stage_count(const Model *m) {
 typedef struct {
   float *x, *h, *qkv, *att, *g1, *g2, *ple, *tmpP, *trow, *logits;
   float *scores; // [seq_len], reused by each attention head
-  float *kcache, *vcache; // [L * seq_len * D]
+  float *kcache, *vcache; // [L * seq_len * D]; unused under LLM_KV_QUANT
+#ifdef LLM_KV_QUANT
+  int8_t  *k8;    // [L][S][H][LLM_KPAD] int8 keys, zero padded
+  float   *ks;    // [L][S][H] key scales
+  int16_t *v16t;  // [L][H][Dh][S] int16 values, one row per feature
+  float   *vs;    // [L][S][H] value scales
+  int8_t  *q8;    // [LLM_KPAD] this head's query, 16-byte aligned
+  int16_t *w16;   // [S] this head's softmax weights, 16-byte aligned
+#endif
 #ifdef LLM_PROFILE
   struct {
     uint64_t input_us, attn_us, ffn_us, ple_us, head_us;
@@ -448,6 +499,27 @@ typedef struct {
 #ifdef LLM_PROFILE
 static void llm_profile_reset(Scratch *s) {
   memset(&s->profile, 0, sizeof(s->profile));
+}
+#endif
+
+#ifdef LLM_KV_QUANT
+/* One allocation holds every quantized-cache buffer; the caller places it
+ * (host: malloc, device: PSRAM or SRAM). Sized with slack for alignment. */
+static inline size_t llm_kv_quant_bytes(const Model *m) {
+  size_t L = m->c.n_layers, S = m->c.seq_len, H = m->c.n_heads, Dh = m->c.dim / m->c.n_heads;
+  return L * S * H * LLM_KPAD + L * H * Dh * S * sizeof(int16_t)
+       + 2 * L * S * H * sizeof(float) + LLM_KPAD + S * sizeof(int16_t) + 64;
+}
+static inline void llm_kv_quant_bind(const Model *m, Scratch *s, void *buffer) {
+  size_t L = m->c.n_layers, S = m->c.seq_len, H = m->c.n_heads, Dh = m->c.dim / m->c.n_heads;
+  uint8_t *p = (uint8_t *)(((uintptr_t)buffer + 15) & ~(uintptr_t)15);
+  s->k8 = (int8_t *)p;    p += L * S * H * LLM_KPAD;           /* 32-byte rows */
+  s->v16t = (int16_t *)p; p += L * H * Dh * S * sizeof(int16_t); /* S*2-byte rows */
+  s->ks = (float *)p;     p += L * S * H * sizeof(float);
+  s->vs = (float *)p;     p += L * S * H * sizeof(float);
+  p = (uint8_t *)(((uintptr_t)p + 15) & ~(uintptr_t)15);
+  s->q8 = (int8_t *)p;    p += LLM_KPAD;
+  s->w16 = (int16_t *)p;
 }
 #endif
 
@@ -507,11 +579,78 @@ static void llm_forward(Model *m, int token, int pos, Scratch *s) {
         kh[i] = k1 * c - k2 * sn; kh[i + Dh / 2] = k2 * c + k1 * sn;
       }
     }
+    float scale = 1.f / sqrtf((float)Dh);
+#ifdef LLM_KV_QUANT
+    // ---- quantized cache: store this position's k (int8) and v (int16)
+    for (int hh = 0; hh < H; hh++) {
+      const float *kh = k + hh * Dh, *vh = v + hh * Dh;
+      float kmax = 1e-8f, vmax = 1e-8f;
+      for (int i = 0; i < Dh; i++) {
+        float a = fabsf(kh[i]); if (a > kmax) kmax = a;
+        a = fabsf(vh[i]);       if (a > vmax) vmax = a;
+      }
+      size_t slot = ((size_t)l * S + pos) * H + hh;
+      int8_t *kd = s->k8 + slot * LLM_KPAD;
+      float kinv = 127.f / kmax;
+      for (int i = 0; i < Dh; i++) {
+        int q8 = (int)lrintf(kh[i] * kinv);
+        kd[i] = (int8_t)(q8 > 127 ? 127 : (q8 < -127 ? -127 : q8));
+      }
+      for (int i = Dh; i < LLM_KPAD; i++) kd[i] = 0;
+      s->ks[slot] = kmax / 127.f;
+      int16_t *vt = s->v16t + ((size_t)l * H + hh) * Dh * S;
+      float vinv = 32767.f / vmax;
+      for (int i = 0; i < Dh; i++) {
+        int q16 = (int)lrintf(vh[i] * vinv);
+        vt[(size_t)i * S + pos] = (int16_t)(q16 > 32767 ? 32767 : (q16 < -32767 ? -32767 : q16));
+      }
+      s->vs[slot] = vmax / 32767.f;
+    }
+    // ---- causal attention over 0..pos, both passes as vector dots
+    int nk = LLM_KPAD / 16, n16 = (pos + 1 + 7) / 8;
+    for (int hh = 0; hh < H; hh++) {
+      float *qh = q + hh * Dh, *ao = s->att + hh * Dh;
+      float qmax = 1e-8f;
+      for (int i = 0; i < Dh; i++) { float a = fabsf(qh[i]); if (a > qmax) qmax = a; }
+      float qinv = 127.f / qmax;
+      for (int i = 0; i < Dh; i++) {
+        int q8 = (int)lrintf(qh[i] * qinv);
+        s->q8[i] = (int8_t)(q8 > 127 ? 127 : (q8 < -127 ? -127 : q8));
+      }
+      for (int i = Dh; i < LLM_KPAD; i++) s->q8[i] = 0;
+      float qs = qmax / 127.f * scale;
+      const int8_t *kb = s->k8 + ((size_t)l * S * H + hh) * LLM_KPAD;
+      const float *ksb = s->ks + (size_t)l * S * H + hh;
+      const float *vsb = s->vs + (size_t)l * S * H + hh;
+      float maxs = -1e30f;
+      for (int t = 0; t <= pos; t++) {
+        float dot = (float)LLM_DOT_S8V(s->q8, kb + (size_t)t * H * LLM_KPAD, nk)
+                    * qs * ksb[(size_t)t * H];
+        s->scores[t] = dot;
+        if (dot > maxs) maxs = dot;
+      }
+      // softmax weights, each multiplied by its position's value scale, to int16
+      float denom = 0.f, wmax = 0.f;
+      for (int t = 0; t <= pos; t++) {
+        float w = expf(s->scores[t] - maxs);
+        denom += w;
+        float wv = w * vsb[(size_t)t * H];
+        s->scores[t] = wv;
+        if (wv > wmax) wmax = wv;
+      }
+      float winv = 32767.f / wmax;
+      for (int t = 0; t <= pos; t++) s->w16[t] = (int16_t)lrintf(s->scores[t] * winv);
+      for (int t = pos + 1; t < n16 * 8; t++) s->w16[t] = 0;
+      float os = wmax / 32767.f / denom;
+      const int16_t *vt = s->v16t + ((size_t)l * H + hh) * Dh * S;
+      for (int i = 0; i < Dh; i++)
+        ao[i] = (float)LLM_DOT_S16V(vt + (size_t)i * S, s->w16, n16) * os;
+    }
+#else
     float *kc = s->kcache + (size_t)l * S * D, *vc = s->vcache + (size_t)l * S * D;
     memcpy(kc + (size_t)pos * D, k, D * sizeof(float));
     memcpy(vc + (size_t)pos * D, v, D * sizeof(float));
     // causal attention over 0..pos
-    float scale = 1.f / sqrtf((float)Dh);
     for (int hh = 0; hh < H; hh++) {
       float *qh = q + hh * Dh;
       float *ao = s->att + hh * Dh;
@@ -533,6 +672,7 @@ static void llm_forward(Model *m, int token, int pos, Scratch *s) {
       }
       for (int i = 0; i < Dh; i++) ao[i] /= denom;
     }
+#endif
     LLM_LMV(m, &m->attn_proj[l], s->att, s->h);
     for (int i = 0; i < D; i++) s->x[i] += s->h[i];
 #ifdef LLM_PROFILE

--- a/runtime/llm_pie.h
+++ b/runtime/llm_pie.h
@@ -73,23 +73,56 @@ static inline void llm_pie4_prepare(const int8_t *xq, int cols, int group,
   }
 }
 
+static inline void llm_pie4_row(const QT *t, const int8_t *xperm, const int32_t *xsum8,
+                                float x_scale, float *y, int r) {
+  int g = t->group, ng = t->n_groups, cols = t->cols;
+  const uint8_t *w = t->w4 + (size_t)r * t->stride4;
+  const float *sc = t->scale8 + (size_t)r * ng;
+  float acc = 0.f;
+  for (int gi = 0; gi < ng; gi++) {
+    int begin = gi * g, span = cols - begin;
+    if (span > g) span = g;
+    int32_t d = llm_pie_dot4(w + begin / 2, xperm + begin, span / 32, llm_pie4_mask)
+                - xsum8[gi];
+    acc += (float)d * sc[gi];
+  }
+  y[r] = acc * x_scale;
+}
+
 // Same result as matvec_q8_range on the flash codes, and as matvec_i8_range.
+//
+// The compute per row is a few dozen instructions; the time is the cache
+// misses on the packed rows in PSRAM. A platform with a cache preload engine
+// defines LLM_PRELOAD_START(addr, bytes) and LLM_PRELOAD_END() before
+// including this file: the rows are then taken in chunks of LLM_PRELOAD_BYTES
+// and each chunk's successor is requested before the chunk is computed, so
+// the engine streams the weights while the vector unit works on the previous
+// chunk. START may block until the engine is free.
 static void matvec_pie4_range(const QT *t, const int8_t *xperm, const int32_t *xsum8,
                               float x_scale, float *y, int row_begin, int row_end) {
-  int g = t->group, ng = t->n_groups, cols = t->cols, stride = t->stride4;
-  for (int r = row_begin; r < row_end; r++) {
-    const uint8_t *w = t->w4 + (size_t)r * stride;
-    const float *sc = t->scale8 + (size_t)r * ng;
-    float acc = 0.f;
-    for (int gi = 0; gi < ng; gi++) {
-      int begin = gi * g, span = cols - begin;
-      if (span > g) span = g;
-      int32_t d = llm_pie_dot4(w + begin / 2, xperm + begin, span / 32, llm_pie4_mask)
-                  - xsum8[gi];
-      acc += (float)d * sc[gi];
-    }
-    y[r] = acc * x_scale;
+#ifdef LLM_PRELOAD_START
+  int stride = t->stride4;
+  int chunk = LLM_PRELOAD_BYTES / stride;
+  if (chunk < 1) chunk = 1;
+  if (row_begin < row_end) {
+    int r1 = row_begin + chunk;
+    if (r1 > row_end) r1 = row_end;
+    LLM_PRELOAD_START(t->w4 + (size_t)row_begin * stride, (size_t)(r1 - row_begin) * stride);
   }
+  for (int r0 = row_begin; r0 < row_end; r0 += chunk) {
+    int r1 = r0 + chunk;
+    if (r1 > row_end) r1 = row_end;
+    if (r1 < row_end) {
+      int r2 = r1 + chunk;
+      if (r2 > row_end) r2 = row_end;
+      LLM_PRELOAD_START(t->w4 + (size_t)r1 * stride, (size_t)(r2 - r1) * stride);
+    }
+    for (int r = r0; r < r1; r++) llm_pie4_row(t, xperm, xsum8, x_scale, y, r);
+  }
+  LLM_PRELOAD_END();
+#else
+  for (int r = row_begin; r < row_end; r++) llm_pie4_row(t, xperm, xsum8, x_scale, y, r);
+#endif
 }
 
 static inline int llm_pie4_ok(const QT *t) {

--- a/runtime/llm_pie.h
+++ b/runtime/llm_pie.h
@@ -1,0 +1,83 @@
+// ESP32-P4 vector kernel for the staged int8 matvec, using the PIE / Xespv
+// extension (TRM chapter 4). Same arithmetic as matvec_i8_range in llm.h:
+// per row, per group, an exact integer dot product scaled by the group's
+// float scale, then by the activation scale. Results are bit-identical to the
+// scalar kernel, which the firmware checks once at boot.
+//
+// ESP.VMULAS.S8.XACC multiplies 16 int8 pairs and adds all 16 products into
+// the 40-bit XACC accumulator in one instruction; the .LD.IP form also loads
+// the next 16 weights. A group of 128 is therefore 8 such steps.
+//
+// Requirements, all arranged by the caller:
+//   - llm.h included with LLM_STAGE_ALIGN 16, so t->stride8 is a multiple of
+//     16 and padding bytes are zero;
+//   - t->w8 16-byte aligned (heap_caps_aligned_alloc), so every row is;
+//   - xq 16-byte aligned and zero from cols up to stride8;
+//   - t->group a multiple of 16.
+// The PIE unit runs in force-alignment mode by default: a misaligned address
+// silently reads the aligned data below it, so these are not optional.
+#ifndef LLM_PIE_H
+#define LLM_PIE_H
+#include <stdint.h>
+#include "llm.h"
+
+#if defined(__riscv) && defined(CONFIG_IDF_TARGET_ESP32P4)
+#define LLM_HAVE_PIE 1
+
+// Dot product of nvec 16-byte vectors; nvec >= 1, pointers 16-byte aligned.
+// The PIE instructions encode only registers x8-x15 and x24-x31, so the
+// operands are pinned to a2-a5 rather than left to the register allocator.
+static inline int32_t llm_pie_dot(const int8_t *w_in, const int8_t *x_in, int nvec) {
+  register const int8_t *w __asm__("a2") = w_in;
+  register const int8_t *x __asm__("a3") = x_in;
+  register int n __asm__("a4") = nvec - 1;
+  register int32_t acc __asm__("a5");
+  __asm__ volatile(
+    "esp.zero.xacc\n"
+    "esp.vld.128.ip q0, %[w], 16\n"
+    "esp.vld.128.ip q1, %[x], 16\n"
+    "beqz %[n], 2f\n"
+    "1:\n"
+    // XACC += q0 . q1 using the values loaded so far, then q0 <- next weights.
+    "esp.vmulas.s8.xacc.ld.ip q0, %[w], 16, q0, q1\n"
+    "esp.vld.128.ip q1, %[x], 16\n"
+    "addi %[n], %[n], -1\n"
+    "bnez %[n], 1b\n"
+    "2:\n"
+    "esp.vmulas.s8.xacc q0, q1\n"
+    "esp.movx.r.xacc.l %[acc]\n"
+    : [acc] "=&r"(acc), [w] "+&r"(w), [x] "+&r"(x), [n] "+&r"(n)
+    :
+    : "memory");
+  return acc;
+}
+
+// Drop-in for matvec_i8_range on a staged tensor that meets the requirements.
+static void matvec_pie_range(const QT *t, const int8_t *xq, float x_scale,
+                             float *y, int row_begin, int row_end) {
+  int g = t->group, ng = t->n_groups, stride = t->stride8;
+  int gvec = g / 16;                       // vectors per full group
+  for (int r = row_begin; r < row_end; r++) {
+    const int8_t *w = t->w8 + (size_t)r * stride;
+    const float *sc = t->scale8 + (size_t)r * ng;
+    float acc = 0.f;
+    for (int gi = 0; gi < ng; gi++) {
+      int begin = gi * g;
+      int span = stride - begin;           // padded bytes left in the row
+      int nvec = span < g ? span / 16 : gvec;
+      acc += (float)llm_pie_dot(w + begin, xq + begin, nvec) * sc[gi];
+    }
+    y[r] = acc * x_scale;
+  }
+}
+
+// Whether a staged tensor can go through the vector kernel.
+static inline int llm_pie_ok(const QT *t) {
+  return t->w8 != NULL && (t->stride8 % 16) == 0 && (t->group % 16) == 0 &&
+         (((uintptr_t)t->w8) & 15) == 0;
+}
+#else
+#define LLM_HAVE_PIE 0
+#endif
+
+#endif

--- a/runtime/llm_pie.h
+++ b/runtime/llm_pie.h
@@ -21,36 +21,10 @@
 #include <stdint.h>
 #include "llm.h"
 
-#if defined(__riscv) && defined(CONFIG_IDF_TARGET_ESP32P4)
-#define LLM_HAVE_PIE 1
+#include "llm_pie_dot.h"
 
-// Dot product of nvec 16-byte vectors; nvec >= 1, pointers 16-byte aligned.
-// The PIE instructions encode only registers x8-x15 and x24-x31, so the
-// operands are pinned to a2-a5 rather than left to the register allocator.
-static inline int32_t llm_pie_dot(const int8_t *w_in, const int8_t *x_in, int nvec) {
-  register const int8_t *w __asm__("a2") = w_in;
-  register const int8_t *x __asm__("a3") = x_in;
-  register int n __asm__("a4") = nvec - 1;
-  register int32_t acc __asm__("a5");
-  __asm__ volatile(
-    "esp.zero.xacc\n"
-    "esp.vld.128.ip q0, %[w], 16\n"
-    "esp.vld.128.ip q1, %[x], 16\n"
-    "beqz %[n], 2f\n"
-    "1:\n"
-    // XACC += q0 . q1 using the values loaded so far, then q0 <- next weights.
-    "esp.vmulas.s8.xacc.ld.ip q0, %[w], 16, q0, q1\n"
-    "esp.vld.128.ip q1, %[x], 16\n"
-    "addi %[n], %[n], -1\n"
-    "bnez %[n], 1b\n"
-    "2:\n"
-    "esp.vmulas.s8.xacc q0, q1\n"
-    "esp.movx.r.xacc.l %[acc]\n"
-    : [acc] "=&r"(acc), [w] "+&r"(w), [x] "+&r"(x), [n] "+&r"(n)
-    :
-    : "memory");
-  return acc;
-}
+#if LLM_HAVE_PIE
+#define llm_pie_dot llm_pie_dot_s8v
 
 // Drop-in for matvec_i8_range on a staged tensor that meets the requirements.
 static void matvec_pie_range(const QT *t, const int8_t *xq, float x_scale,
@@ -76,8 +50,6 @@ static inline int llm_pie_ok(const QT *t) {
   return t->w8 != NULL && (t->stride8 % 16) == 0 && (t->group % 16) == 0 &&
          (((uintptr_t)t->w8) & 15) == 0;
 }
-#else
-#define LLM_HAVE_PIE 0
 #endif
 
 #endif

--- a/runtime/llm_pie.h
+++ b/runtime/llm_pie.h
@@ -45,6 +45,58 @@ static void matvec_pie_range(const QT *t, const int8_t *xq, float x_scale,
   }
 }
 
+// ---- int4 weights, unpacked in registers ------------------------------------
+// For a tensor staged with llm_stage_int4 whose cols and group are multiples
+// of 32. Reads half the bytes of the int8 kernel; the head is bandwidth-bound,
+// so that is where the time goes.
+static const uint8_t llm_pie4_mask[16] __attribute__((aligned(16))) = {
+  0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
+  0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F };
+
+// Lay out the int8 activations for llm_pie_dot4 and compute 8 * sum(x) per
+// group, the correction that turns code * x into (code - 8) * x.
+static inline void llm_pie4_prepare(const int8_t *xq, int cols, int group,
+                                    int8_t *xperm, int32_t *xsum8) {
+  for (int c = 0; c < cols / 32; c++) {
+    for (int i = 0; i < 16; i++) {
+      xperm[c * 32 + i]      = xq[c * 32 + 2 * i];
+      xperm[c * 32 + 16 + i] = xq[c * 32 + 2 * i + 1];
+    }
+  }
+  int ng = (cols + group - 1) / group;
+  for (int gi = 0; gi < ng; gi++) {
+    int begin = gi * group, end = begin + group;
+    if (end > cols) end = cols;
+    int32_t sum = 0;
+    for (int j = begin; j < end; j++) sum += xq[j];
+    xsum8[gi] = 8 * sum;
+  }
+}
+
+// Same result as matvec_q8_range on the flash codes, and as matvec_i8_range.
+static void matvec_pie4_range(const QT *t, const int8_t *xperm, const int32_t *xsum8,
+                              float x_scale, float *y, int row_begin, int row_end) {
+  int g = t->group, ng = t->n_groups, cols = t->cols, stride = t->stride4;
+  for (int r = row_begin; r < row_end; r++) {
+    const uint8_t *w = t->w4 + (size_t)r * stride;
+    const float *sc = t->scale8 + (size_t)r * ng;
+    float acc = 0.f;
+    for (int gi = 0; gi < ng; gi++) {
+      int begin = gi * g, span = cols - begin;
+      if (span > g) span = g;
+      int32_t d = llm_pie_dot4(w + begin / 2, xperm + begin, span / 32, llm_pie4_mask)
+                  - xsum8[gi];
+      acc += (float)d * sc[gi];
+    }
+    y[r] = acc * x_scale;
+  }
+}
+
+static inline int llm_pie4_ok(const QT *t) {
+  return t->w4 != NULL && (t->cols % 32) == 0 && (t->group % 32) == 0 &&
+         (((uintptr_t)t->w4) & 15) == 0 && (t->stride4 % 16) == 0;
+}
+
 // Whether a staged tensor can go through the vector kernel.
 static inline int llm_pie_ok(const QT *t) {
   return t->w8 != NULL && (t->stride8 % 16) == 0 && (t->group % 16) == 0 &&

--- a/runtime/llm_pie_dot.h
+++ b/runtime/llm_pie_dot.h
@@ -1,0 +1,72 @@
+// ESP32-P4 PIE / Xespv vector dot products (TRM chapter 4). No dependency on
+// llm.h, so a platform can define LLM_DOT_S8V / LLM_DOT_S16V to these before
+// including it.
+//
+// ESP.VMULAS.S8.XACC multiplies 16 int8 pairs and adds all products into the
+// 40-bit XACC accumulator; the S16 form does 8 int16 pairs. The .LD.IP forms
+// also load the next vector. Results are exact integers, identical to the
+// scalar reference in llm.h, which the firmware checks at boot.
+//
+// The PIE instructions encode only registers x8-x15 and x24-x31, so operands
+// are pinned to a2-a5. Loads must be 16-byte aligned: the unit runs in
+// force-alignment mode and silently reads the aligned address below.
+#ifndef LLM_PIE_DOT_H
+#define LLM_PIE_DOT_H
+#include <stdint.h>
+
+#if defined(__riscv) && defined(CONFIG_IDF_TARGET_ESP32P4)
+#define LLM_HAVE_PIE 1
+
+// nvec*16 int8 pairs; nvec >= 1.
+static inline int32_t llm_pie_dot_s8v(const int8_t *a_in, const int8_t *b_in, int nvec) {
+  register const int8_t *a __asm__("a2") = a_in;
+  register const int8_t *b __asm__("a3") = b_in;
+  register int n __asm__("a4") = nvec - 1;
+  register int32_t acc __asm__("a5");
+  __asm__ volatile(
+    "esp.zero.xacc\n"
+    "esp.vld.128.ip q0, %[a], 16\n"
+    "esp.vld.128.ip q1, %[b], 16\n"
+    "beqz %[n], 2f\n"
+    "1:\n"
+    "esp.vmulas.s8.xacc.ld.ip q0, %[a], 16, q0, q1\n"
+    "esp.vld.128.ip q1, %[b], 16\n"
+    "addi %[n], %[n], -1\n"
+    "bnez %[n], 1b\n"
+    "2:\n"
+    "esp.vmulas.s8.xacc q0, q1\n"
+    "esp.movx.r.xacc.l %[acc]\n"
+    : [acc] "=&r"(acc), [a] "+&r"(a), [b] "+&r"(b), [n] "+&r"(n) :: "memory");
+  return acc;
+}
+
+// nvec*8 int16 pairs; nvec >= 1. The sum can exceed 32 bits, so both halves of
+// XACC are read: the high instruction returns bits 39:32 zero-extended.
+static inline int64_t llm_pie_dot_s16v(const int16_t *a_in, const int16_t *b_in, int nvec) {
+  register const int16_t *a __asm__("a2") = a_in;
+  register const int16_t *b __asm__("a3") = b_in;
+  register int n __asm__("a4") = nvec - 1;
+  register uint32_t lo __asm__("a5");
+  register uint32_t hi __asm__("a0");
+  __asm__ volatile(
+    "esp.zero.xacc\n"
+    "esp.vld.128.ip q0, %[a], 16\n"
+    "esp.vld.128.ip q1, %[b], 16\n"
+    "beqz %[n], 2f\n"
+    "1:\n"
+    "esp.vmulas.s16.xacc.ld.ip q0, %[a], 16, q0, q1\n"
+    "esp.vld.128.ip q1, %[b], 16\n"
+    "addi %[n], %[n], -1\n"
+    "bnez %[n], 1b\n"
+    "2:\n"
+    "esp.vmulas.s16.xacc q0, q1\n"
+    "esp.movx.r.xacc.l %[lo]\n"
+    "esp.movx.r.xacc.h %[hi]\n"
+    : [lo] "=&r"(lo), [hi] "=&r"(hi), [a] "+&r"(a), [b] "+&r"(b), [n] "+&r"(n) :: "memory");
+  return ((int64_t)(int8_t)(hi & 0xFF) << 32) | (int64_t)lo;
+}
+#else
+#define LLM_HAVE_PIE 0
+#endif
+
+#endif

--- a/runtime/llm_pie_dot.h
+++ b/runtime/llm_pie_dot.h
@@ -65,6 +65,43 @@ static inline int64_t llm_pie_dot_s16v(const int16_t *a_in, const int16_t *b_in,
     : [lo] "=&r"(lo), [hi] "=&r"(hi), [a] "+&r"(a), [b] "+&r"(b), [n] "+&r"(n) :: "memory");
   return ((int64_t)(int8_t)(hi & 0xFF) << 32) | (int64_t)lo;
 }
+// Dot product of nchunk chunks of 32 packed int4 weights against int8
+// activations laid out to match the unpacking: for each chunk, the 16
+// activations at even indices then the 16 at odd indices (llm_pie4_prepare).
+// A 16-byte load of packed bytes gives the even weights in the low nibbles
+// and the odd weights in the high nibbles; AND with 0x0F and a 4-bit shift of
+// each 32-bit lane followed by the same AND separate them. The codes are
+// used as they are (0..15): the caller subtracts 8 * sum(x), which is what
+// makes the result identical to (code - 8) * x. nchunk >= 1.
+static inline int32_t llm_pie_dot4(const uint8_t *w_in, const int8_t *xp_in,
+                                   int nchunk, const uint8_t *mask16) {
+  register const uint8_t *w __asm__("a2") = w_in;
+  register const int8_t *x __asm__("a3") = xp_in;
+  register int n __asm__("a4") = nchunk;
+  register int32_t acc __asm__("a5");
+  register const uint8_t *mk __asm__("a0") = mask16;
+  register int sar __asm__("a1") = 4;
+  __asm__ volatile(
+    "esp.movx.w.sar %[sar]\n"
+    "esp.vld.128.ip q6, %[mk], 0\n"
+    "esp.zero.xacc\n"
+    "1:\n"
+    "esp.vld.128.ip q0, %[w], 16\n"
+    "esp.vld.128.ip q4, %[x], 16\n"
+    "esp.vld.128.ip q5, %[x], 16\n"
+    "esp.andq q2, q0, q6\n"
+    "esp.vsr.u32 q3, q0\n"
+    "esp.andq q3, q3, q6\n"
+    "esp.vmulas.s8.xacc q2, q4\n"
+    "esp.vmulas.s8.xacc q3, q5\n"
+    "addi %[n], %[n], -1\n"
+    "bnez %[n], 1b\n"
+    "esp.movx.r.xacc.l %[acc]\n"
+    : [acc] "=&r"(acc), [w] "+&r"(w), [x] "+&r"(x), [n] "+&r"(n), [mk] "+&r"(mk)
+    : [sar] "r"(sar)
+    : "memory");
+  return acc;
+}
 #else
 #define LLM_HAVE_PIE 0
 #endif

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -106,6 +106,12 @@ prepare_headers() {
       SHOW=wrote step 0 "generate vocab.h" \
         uv run --no-project --with 'tokenizers==0.23.1' python "$SKETCH/tools/generate_vocab.py" \
         --tokenizer "$TOKENIZER" --out "$SKETCH/generated/vocab.h"
+      # The sketch takes a typed prompt, so it needs the encoder as well as the
+      # decode table.
+      echo "=== generate encoder asset from $TOKENIZER ==="
+      SHOW=wrote step 0 "generate encoder asset" \
+        uv run --no-project python "$SKETCH/tools/generate_tokenizer_header.py" \
+        --tokenizer "$TOKENIZER" --out "$SKETCH/generated/tokenizer_encoder.h"
       ;;
     barista)
       echo "=== generate word tables from $VOCAB and $LAYOUT ==="
@@ -141,7 +147,25 @@ extra_gates() {
 # --- everything below is shared ---------------------------------------------
 PART_OFFSET=0x110000
 
-FQBN='esp32:esp32:esp32s3:UploadSpeed=921600,USBMode=hwcdc,CDCOnBoot=cdc,UploadMode=default,CPUFreq=240,FlashMode=qio,FlashSize=16M,PartitionScheme=custom,PSRAM=opi,DebugLevel=info'
+# CDC_ON_BOOT selects where Serial goes: cdc for the chip's native USB port
+# (the default), default for UART0 when the cable is in the board's UART port.
+CDC_ON_BOOT=${CDC_ON_BOOT:-cdc}
+# CHIP selects the target: esp32s3 (the N16R8 the project was built for) or
+# esp32p4 (ESP32-P4NRW32, 32 MB flash and PSRAM; Serial defaults to UART0 there
+# because its dev boards expose a UART bridge, so pass CDC_ON_BOOT=default).
+CHIP=${CHIP:-esp32s3}
+case "$CHIP" in
+  esp32s3)
+    FQBN="esp32:esp32:esp32s3:UploadSpeed=921600,USBMode=hwcdc,CDCOnBoot=$CDC_ON_BOOT,UploadMode=default,CPUFreq=240,FlashMode=qio,FlashSize=16M,PartitionScheme=custom,PSRAM=opi,DebugLevel=info"
+    ;;
+  esp32p4)
+    FQBN="esp32:esp32:esp32p4:UploadSpeed=921600,USBMode=hwcdc,CDCOnBoot=$CDC_ON_BOOT,UploadMode=default,FlashMode=qio,FlashFreq=80,FlashSize=32M,PartitionScheme=custom,PSRAM=enabled,DebugLevel=info"
+    ;;
+  *)
+    echo "CHIP must be esp32s3 or esp32p4, got '$CHIP'" >&2
+    exit 2
+    ;;
+esac
 
 # -O3, overriding the Arduino core default of -Os. The runtime carries no
 # per-function optimization attributes; this flag is the whole configuration.
@@ -238,6 +262,7 @@ BYTES=$(wc -c < "$MODEL" | tr -d ' ')
 echo
 echo "=== about to flash, replacing the model now on the board ==="
 printf "  model   : %s\n" "$MODEL_KIND"
+printf "  chip    : %s\n" "$CHIP"
 printf "  sketch  : %s\n" "$SKETCH"
 printf "  binary  : %s\n" "$MODEL"
 printf "  port    : %s\n" "$PORT"
@@ -247,7 +272,7 @@ echo
 
 echo "=== flash model -> $PORT @ $PART_OFFSET ==="
 step 2 "flash model" \
-  "$ESPTOOL" --chip esp32s3 --port "$PORT" --baud 921600 \
+  "$ESPTOOL" --chip "$CHIP" --port "$PORT" --baud 921600 \
   write_flash "$PART_OFFSET" "$MODEL"
 
 # --input-dir: `upload` does not rebuild, so point it at the build just made.

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -298,7 +298,7 @@ class ToolsRunOutsideTheProjectEnvironment(DeployHarness):
                                    "vocab.json", "layout.json"])
 
     def test_no_uv_call_uses_the_project_environment(self):
-        for model, expected in (("barista", 3), ("tinystories", 1)):
+        for model, expected in (("barista", 3), ("tinystories", 2)):
             with self.subTest(model=model):
                 self.log.unlink(missing_ok=True)
                 self.assertEqual(self.run_deploy(model).returncode, 0)


### PR DESCRIPTION
Follows up on #23. Same model.bin and the same runtime, run on an ESP32-P4 (Waveshare ESP32-P4-WIFI6, ESP32-P4NRW32) at 63 tok/s, against 10.5 tok/s on the ESP32-S3 N16R8. The ESP32-S3 build is unchanged in behaviour.

## What is in here

- `scripts/deploy.sh`: `CHIP=esp32s3|esp32p4` target and a `CDC_ON_BOOT` override for boards whose USB connector is a UART bridge.
- TinyStories firmware takes a prompt typed over serial, encoded on the device with the TinyStories BPE (the Barista packer, accepting the `<|endoftext|>` special token), top-k sampling, stops at end of text.
- `runtime/llm_pie_dot.h`, `runtime/llm_pie.h`: int8 and int4 matvecs and the attention dot products on the P4's PIE vector unit (`esp.vmulas.s8/s16.xacc`). Every kernel is compared against the scalar reference at boot and must match bit for bit.
- `runtime/llm.h`: staged rows padded to `LLM_STAGE_ALIGN` (default 1, so the host path is byte-identical); an optional quantized KV cache (`LLM_KV_QUANT`: int8 keys, int16 transposed values) with a per-layer attention hook so heads can run on both cores; int4 staging of the head.
- The output head stays int4 in PSRAM and is unpacked in registers; the L1 cache preload engine fetches the next block of rows while the current one computes.

## Measurements, 200-token story, ms per token

| step | tok/s | ms/token | head | attention |
|---|---:|---:|---:|---:|
| ESP32-S3 N16R8 (this repo, unchanged) | 10.5 | 93.3 | 58.6 | 17.7 |
| ESP32-P4, code unchanged | 17.0 | 57.2 | 38.3 | 10.2 |
| + PIE int8 matvec | 39.6 | 23.8 | 12.6 | 8.0 |
| + quantized KV attention | 43.0 | 21.8 | 12.6 | 6.0 |
| + int4 head, vector unpack | 54 | 17.2 | 8.3 | 5.7 |
| + attention on both cores | 57.5 | 16.0 | 8.3 | 4.5 |
| + L1 preload of head rows | 63 | 14.6 | 7.1 | 4.4 |

Bandwidth sketch on the P4: PSRAM 156 MB/s sequential, flash random 512 B row 15.8 µs.

## Quality

- Host `ppl.c` over 32,768 predictions of public TinyStories validation text, tokenized with the shipped tokenizer: 2.1012 nats with the fp32 KV cache, 2.1014 with the quantized one.
- `staging_verify` passes at `LLM_STAGE_ALIGN` 1 and 16; host tools build warning-free with `-Wall -Wextra`.
- `tests/`: 75 tests pass (`test_deploy` expects two `uv` calls for TinyStories now, since the encoder header is generated too).

## Notes

- The README section is written from the fork's perspective; glad to reword it or move the numbers into RESULTS.md, whichever you prefer.
- Arduino core 3.3.10 with the esp32p4 libraries; the P4 build uses the same `-O3` and partition layout.
- I can split this into two PRs (serial prompting / P4 port) if that is easier to review.